### PR TITLE
feat: add more project features

### DIFF
--- a/snyk/client.go
+++ b/snyk/client.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	libraryVersion   = "0.4.1"
-	defaultBaseURL   = "https://snyk.io/api/"
+	defaultBaseURL   = "https://api.snyk.io/api/"
 	defaultMediaType = "application/json"
 	defaultUserAgent = "snyk-sdk-go/" + libraryVersion + " (+https://github.com/pavel-snyk/snyk-sdk-go)"
 

--- a/snyk/issue.go
+++ b/snyk/issue.go
@@ -1,0 +1,8 @@
+package snyk
+
+type IssueCounts struct {
+	Low      int `json:"low"`
+	Medium   int `json:"medium"`
+	High     int `json:"high"`
+	Critical int `json:"critical"`
+}

--- a/snyk/projects.go
+++ b/snyk/projects.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"time"
 )
 
 const projectBasePath = "org/%v/projects"
+const projectPath = "org/%s/project/%s"
+const projectTagsPath = "org/%s/project/%s/tags"
 
 // ProjectsService handles communication with the project related methods of the Snyk API.
 type ProjectsService service
@@ -16,11 +19,19 @@ type Project struct {
 	ID     string `json:"id,omitempty"`
 	Name   string `json:"name,omitempty"`
 	Origin string `json:"origin,omitempty"`
+
+	svc *ProjectsService
+	org *Organization
 }
 
 type projectsRoot struct {
 	Organization Organization `json:"org,omitempty"`
 	Projects     []Project    `json:"projects,omitempty"`
+}
+
+type projectAddTagRequest struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }
 
 // List provides a list of all projects for the given organization.
@@ -41,5 +52,93 @@ func (s *ProjectsService) List(ctx context.Context, organizationID string) ([]Pr
 		return nil, resp, err
 	}
 
+	for k, v := range root.Projects {
+		v.svc = s
+		v.org = &root.Organization
+		root.Projects[k] = v
+	}
+
 	return root.Projects, resp, nil
+}
+
+type Tag struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+type ProjectDetails struct {
+	Name                  string             `json:"name"`
+	Id                    string             `json:"id"`
+	Created               time.Time          `json:"created"`
+	Origin                string             `json:"origin"`
+	Type                  string             `json:"type"`
+	ReadOnly              bool               `json:"readOnly"`
+	TestFrequency         string             `json:"testFrequency"`
+	TotalDependencies     int                `json:"totalDependencies"`
+	IssueCountsBySeverity IssueCounts        `json:"issueCountsBySeverity"`
+	ImageId               string             `json:"imageId"`
+	ImageTag              string             `json:"imageTag"`
+	ImageBaseImage        string             `json:"imageBaseImage"`
+	ImagePlatform         string             `json:"imagePlatform"`
+	ImageCluster          string             `json:"imageCluster"`
+	Hostname              string             `json:"hostname"`
+	RemoteRepoUrl         string             `json:"remoteRepoUrl"`
+	LastTestedDate        time.Time          `json:"lastTestedDate"`
+	BrowseUrl             string             `json:"browseUrl"`
+	ImportingUser         UserRef            `json:"importingUser"`
+	IsMonitored           bool               `json:"isMonitored"`
+	Branch                string             `json:"branch"`
+	TargetReference       string             `json:"targetReference"`
+	Tags                  []Tag              `json:"tags"`
+	Attributes            ProjectAttributes  `json:"attributes"`
+	Remediation           ProjectRemediation `json:"remediation"`
+}
+
+type ProjectAttributes struct {
+	Criticality []string `json:"criticality"`
+	Environment []string `json:"environment"`
+	Lifecycle   []string `json:"lifecycle"`
+}
+
+type ProjectRemediation struct {
+	Upgrade struct{} `json:"upgrade"`
+	Patch   struct{} `json:"patch"`
+	Pin     struct{} `json:"pin"`
+}
+
+func (p *Project) AddTag(ctx context.Context, key string, value string) ([]Tag, *Response, error) {
+	path := fmt.Sprintf(projectTagsPath, p.org.ID, p.ID)
+
+	req, err := p.svc.client.NewRequest(http.MethodPost, path, projectAddTagRequest{
+		Key:   key,
+		Value: value,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new([]Tag)
+	resp, err := p.svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return *root, resp, nil
+}
+
+func (p *Project) Details(ctx context.Context) (*ProjectDetails, *Response, error) {
+	path := fmt.Sprintf(projectPath, p.org.ID, p.ID)
+
+	req, err := p.svc.client.NewRequest(http.MethodGet, path, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	root := new(ProjectDetails)
+	resp, err := p.svc.client.Do(ctx, req, root)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return root, resp, nil
 }

--- a/snyk/users.go
+++ b/snyk/users.go
@@ -20,6 +20,13 @@ type User struct {
 	Organizations []Organization `json:"orgs,omitempty"`
 }
 
+type UserRef struct {
+	Id       string `json:"id"`
+	Name     string `json:"name"`
+	Username string `json:"username"`
+	Email    string `json:"email"`
+}
+
 // GetCurrent retrieves information about the user making the request.
 //
 // Note: the retrieved user will include information about organizations


### PR DESCRIPTION
This PR adds two methods:

- `*Project.Details(ctx)`: https://snyk.docs.apiary.io/#reference/projects/individual-project/retrieve-a-single-project  
- `*Project.AddTag(ctx, key, value)`: https://snyk.docs.apiary.io/#reference/projects/project-tags/add-a-tag-to-a-project 

Other changes:

- `Project` now includes a `svc` and `org` field, so that one doesn't need to call `*ProjectService.Details(prj *Project)`
- `Project` now includes an `org` field, populated when it's returned from `ListProjects`