### PR TITLE
fix: remove API version query param from public surface

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,8 +58,9 @@ them in a PR.
   version-override `ClientOption`. (Snyk versions per-endpoint, not
   per-service or globally — a single override can't express that
   correctly, so don't add one that pretends to.)
-- The SDK surfaces server-provided facts (`SnykRequestID`, `RetryAfter`,
-  `Sunset`) as struct fields. It never acts on them automatically.
+- The SDK surfaces server-provided facts (`SnykRequestID`,
+  `ServedAPIVersion`, `RetryAfter`, `Sunset`) as struct fields. It never
+  acts on them automatically.
 
 ## 4. Conventions
 
@@ -91,6 +92,9 @@ Follow these steps in order. Each step has a known failure mode if skipped.
 
 3. **Declare the version constant** at the top of the file:
    `const xAPIVersion = "<version-from-step-1>"`.
+   Build REST request paths with
+   `restPath(endpoint, xAPIVersion, opts)`; never expose the version on
+   public option structs.
 
 4. **Define `XServiceAPI` interface** with all public methods, each with
    a doc comment linking to the Snyk API docs page for that endpoint.
@@ -102,5 +106,10 @@ Follow these steps in order. Each step has a known failure mode if skipped.
    - Add the field to the `Client` struct: `X XServiceAPI`
    - Assign it in `NewClient`: `c.X = (*XService)(&c.common)`
 
-   Forgetting this step means the service compiles but is unreachable
-   from `client.X`.
+Forgetting this step means the service compiles but is unreachable
+from `client.X`.
+
+## 6. Verification
+
+- Run `make test` for the full test suite and coverage report.
+- Run `make lint` before considering implementation work complete.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/snyk/apps.go
+++ b/snyk/apps.go
@@ -103,9 +103,8 @@ func (s *AppsService) ListAppInstallsForOrg(ctx context.Context, orgID string, o
 	if opts == nil {
 		opts = &ListAppInstallOptions{Expand: "app"}
 	}
-	opts.Version = appsAPIVersion
 
-	path, err := addOptions(fmt.Sprintf("orgs/%v/%v/installs", orgID, appsBasePath), opts)
+	path, err := restPath(fmt.Sprintf("orgs/%v/%v/installs", orgID, appsBasePath), appsAPIVersion, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -135,8 +134,7 @@ func (s *AppsService) CreateAppInstallForOrg(ctx context.Context, orgID, appID s
 		return nil, nil, errors.New("failed to create app install for org: app id must be supplied")
 	}
 
-	opts := &ListOptions{BaseOptions: BaseOptions{Version: appsAPIVersion}}
-	path, err := addOptions(fmt.Sprintf("orgs/%v/%v/installs", orgID, appsBasePath), opts)
+	path, err := restPath(fmt.Sprintf("orgs/%v/%v/installs", orgID, appsBasePath), appsAPIVersion, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -180,8 +178,7 @@ func (s *AppsService) DeleteAppInstallFromOrg(ctx context.Context, orgID, appIns
 		return nil, errors.New("failed to delete app install for org: app install id must be supplied")
 	}
 
-	opts := &ListOptions{BaseOptions: BaseOptions{Version: appsAPIVersion}}
-	path, err := addOptions(fmt.Sprintf("orgs/%v/%v/installs/%v", orgID, appsBasePath, appInstallID), opts)
+	path, err := restPath(fmt.Sprintf("orgs/%v/%v/installs/%v", orgID, appsBasePath, appInstallID), appsAPIVersion, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/snyk/apps_test.go
+++ b/snyk/apps_test.go
@@ -1,0 +1,23 @@
+package snyk
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestApps_DeleteAppInstallFromOrg(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/org-id/apps/installs/install-id", func(w http.ResponseWriter, r *http.Request) {
+		assertRequestAPIVersion(t, r, appsAPIVersion)
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	response, err := client.Apps.DeleteAppInstallFromOrg(ctx, "org-id", "install-id")
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusNoContent, response.StatusCode)
+}

--- a/snyk/brokers.go
+++ b/snyk/brokers.go
@@ -158,9 +158,7 @@ func (s *BrokersService) ListDeployments(ctx context.Context, tenantID, appInsta
 		return nil, nil, errors.New("failed to list broker deployments: app install id must be supplied")
 	}
 
-	opts := BaseOptions{Version: brokersAPIVersion}
-
-	path, err := addOptions(fmt.Sprintf("%v/%v/%v/installs/%v/deployments", tenantsBasePath, tenantID, brokersBasePath, appInstallID), opts)
+	path, err := restPath(fmt.Sprintf("%v/%v/%v/installs/%v/deployments", tenantsBasePath, tenantID, brokersBasePath, appInstallID), brokersAPIVersion, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -187,9 +185,7 @@ func (s *BrokersService) ListDeploymentsForTenant(ctx context.Context, tenantID 
 		return nil, nil, errors.New("failed to list broker deployments: tenant id must be supplied")
 	}
 
-	opts := BaseOptions{Version: brokersAPIVersion}
-
-	path, err := addOptions(fmt.Sprintf("%v/%v/brokers/deployments", tenantsBasePath, tenantID), opts)
+	path, err := restPath(fmt.Sprintf("%v/%v/brokers/deployments", tenantsBasePath, tenantID), brokersAPIVersion, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -222,9 +218,7 @@ func (s *BrokersService) CreateDeployment(ctx context.Context, tenantID, appInst
 		return nil, nil, errors.New("failed to create broker deployment: payload must be supplied")
 	}
 
-	opts := BaseOptions{Version: brokersAPIVersion}
-
-	path, err := addOptions(fmt.Sprintf("%v/%v/%v/installs/%v/deployments", tenantsBasePath, tenantID, brokersBasePath, appInstallID), opts)
+	path, err := restPath(fmt.Sprintf("%v/%v/%v/installs/%v/deployments", tenantsBasePath, tenantID, brokersBasePath, appInstallID), brokersAPIVersion, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -275,9 +269,7 @@ func (s *BrokersService) UpdateDeployment(ctx context.Context, tenantID, appInst
 		return nil, nil, errors.New("failed to update broker deployment: payload must be supplied")
 	}
 
-	opts := BaseOptions{Version: brokersAPIVersion}
-
-	path, err := addOptions(fmt.Sprintf("%v/%v/%v/installs/%v/deployments/%v", tenantsBasePath, tenantID, brokersBasePath, appInstallID, deploymentID), opts)
+	path, err := restPath(fmt.Sprintf("%v/%v/%v/installs/%v/deployments/%v", tenantsBasePath, tenantID, brokersBasePath, appInstallID, deploymentID), brokersAPIVersion, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -327,9 +319,7 @@ func (s *BrokersService) DeleteDeployment(ctx context.Context, tenantID, appInst
 		return nil, errors.New("failed to delete broker deployment: id must be supplied")
 	}
 
-	opts := BaseOptions{Version: brokersAPIVersion}
-
-	path, err := addOptions(fmt.Sprintf("%v/%v/%v/installs/%v/deployments/%v", tenantsBasePath, tenantID, brokersBasePath, appInstallID, deploymentID), opts)
+	path, err := restPath(fmt.Sprintf("%v/%v/%v/installs/%v/deployments/%v", tenantsBasePath, tenantID, brokersBasePath, appInstallID, deploymentID), brokersAPIVersion, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -386,9 +376,7 @@ func (s *BrokersService) ListDeploymentCredentials(ctx context.Context, tenantID
 		return nil, nil, errors.New("failed to list broker deployment credentials: deployment id must be supplied")
 	}
 
-	opts := BaseOptions{Version: brokersAPIVersion}
-
-	path, err := addOptions(fmt.Sprintf("%v/%v/%v/installs/%v/deployments/%v/credentials", tenantsBasePath, tenantID, brokersBasePath, appInstallID, deploymentID), opts)
+	path, err := restPath(fmt.Sprintf("%v/%v/%v/installs/%v/deployments/%v/credentials", tenantsBasePath, tenantID, brokersBasePath, appInstallID, deploymentID), brokersAPIVersion, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -424,9 +412,7 @@ func (s *BrokersService) GetDeploymentCredential(ctx context.Context, tenantID, 
 		return nil, nil, errors.New("failed to get broker deployment credential: credential id must be supplied")
 	}
 
-	opts := BaseOptions{Version: brokersAPIVersion}
-
-	path, err := addOptions(fmt.Sprintf("%v/%v/%v/installs/%v/deployments/%v/credentials/%v", tenantsBasePath, tenantID, brokersBasePath, appInstallID, deploymentID, credentialID), opts)
+	path, err := restPath(fmt.Sprintf("%v/%v/%v/installs/%v/deployments/%v/credentials/%v", tenantsBasePath, tenantID, brokersBasePath, appInstallID, deploymentID, credentialID), brokersAPIVersion, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -459,9 +445,7 @@ func (s *BrokersService) CreateDeploymentCredential(ctx context.Context, tenantI
 		return nil, nil, errors.New("failed to create broker deployment credentials: payload must be supplied")
 	}
 
-	opts := BaseOptions{Version: brokersAPIVersion}
-
-	path, err := addOptions(fmt.Sprintf("%v/%v/%v/installs/%v/deployments/%v/credentials", tenantsBasePath, tenantID, brokersBasePath, appInstallID, deploymentID), opts)
+	path, err := restPath(fmt.Sprintf("%v/%v/%v/installs/%v/deployments/%v/credentials", tenantsBasePath, tenantID, brokersBasePath, appInstallID, deploymentID), brokersAPIVersion, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -516,9 +500,7 @@ func (s *BrokersService) UpdateDeploymentCredential(ctx context.Context, tenantI
 		return nil, nil, errors.New("failed to update broker deployment credential: payload must be supplied")
 	}
 
-	opts := BaseOptions{Version: brokersAPIVersion}
-
-	path, err := addOptions(fmt.Sprintf("%v/%v/%v/installs/%v/deployments/%v/credentials/%v", tenantsBasePath, tenantID, brokersBasePath, appInstallID, deploymentID, credentialID), opts)
+	path, err := restPath(fmt.Sprintf("%v/%v/%v/installs/%v/deployments/%v/credentials/%v", tenantsBasePath, tenantID, brokersBasePath, appInstallID, deploymentID, credentialID), brokersAPIVersion, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -567,9 +549,7 @@ func (s *BrokersService) DeleteDeploymentCredential(ctx context.Context, tenantI
 		return nil, errors.New("failed to delete broker deployment credential: credential id must be supplied")
 	}
 
-	opts := BaseOptions{Version: brokersAPIVersion}
-
-	path, err := addOptions(fmt.Sprintf("%v/%v/%v/installs/%v/deployments/%v/credentials/%v", tenantsBasePath, tenantID, brokersBasePath, appInstallID, deploymentID, credentialID), opts)
+	path, err := restPath(fmt.Sprintf("%v/%v/%v/installs/%v/deployments/%v/credentials/%v", tenantsBasePath, tenantID, brokersBasePath, appInstallID, deploymentID, credentialID), brokersAPIVersion, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1025,9 +1005,7 @@ func (s *BrokersService) ListConnections(ctx context.Context, tenantID, appInsta
 		return nil, nil, errors.New("failed to list broker connections: deployment id must be supplied")
 	}
 
-	opts := BaseOptions{Version: brokersAPIVersion}
-
-	path, err := addOptions(fmt.Sprintf(brokerConnectionsBasePath, tenantID, appInstallID, deploymentID), opts)
+	path, err := restPath(fmt.Sprintf(brokerConnectionsBasePath, tenantID, appInstallID, deploymentID), brokersAPIVersion, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1063,9 +1041,7 @@ func (s *BrokersService) GetConnection(ctx context.Context, tenantID, appInstall
 		return nil, nil, errors.New("failed to get broker connection: connection id must be supplied")
 	}
 
-	opts := BaseOptions{Version: brokersAPIVersion}
-
-	path, err := addOptions(fmt.Sprintf(brokerConnectionBasePath, tenantID, appInstallID, deploymentID, connectionID), opts)
+	path, err := restPath(fmt.Sprintf(brokerConnectionBasePath, tenantID, appInstallID, deploymentID, connectionID), brokersAPIVersion, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1098,9 +1074,7 @@ func (s *BrokersService) CreateConnection(ctx context.Context, tenantID, appInst
 		return nil, nil, errors.New("failed to create broker connection: payload must be supplied")
 	}
 
-	opts := BaseOptions{Version: brokersAPIVersion}
-
-	path, err := addOptions(fmt.Sprintf(brokerConnectionsBasePath, tenantID, appInstallID, deploymentID), opts)
+	path, err := restPath(fmt.Sprintf(brokerConnectionsBasePath, tenantID, appInstallID, deploymentID), brokersAPIVersion, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1141,9 +1115,7 @@ func (s *BrokersService) UpdateConnection(ctx context.Context, tenantID, appInst
 		return nil, nil, errors.New("failed to update broker connection: payload must be supplied")
 	}
 
-	opts := BaseOptions{Version: brokersAPIVersion}
-
-	path, err := addOptions(fmt.Sprintf(brokerConnectionBasePath, tenantID, appInstallID, deploymentID, connectionID), opts)
+	path, err := restPath(fmt.Sprintf(brokerConnectionBasePath, tenantID, appInstallID, deploymentID, connectionID), brokersAPIVersion, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1181,9 +1153,7 @@ func (s *BrokersService) DeleteConnection(ctx context.Context, tenantID, appInst
 		return nil, errors.New("failed to delete broker connection: connection id must be supplied")
 	}
 
-	opts := BaseOptions{Version: brokersAPIVersion}
-
-	path, err := addOptions(fmt.Sprintf(brokerConnectionBasePath, tenantID, appInstallID, deploymentID, connectionID), opts)
+	path, err := restPath(fmt.Sprintf(brokerConnectionBasePath, tenantID, appInstallID, deploymentID, connectionID), brokersAPIVersion, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1716,9 +1686,7 @@ func (s *BrokersService) ListIntegrations(ctx context.Context, tenantID, connect
 		return nil, nil, errors.New("failed to list broker integrations: connection id must be supplied")
 	}
 
-	opts := BaseOptions{Version: brokersAPIVersion}
-
-	path, err := addOptions(fmt.Sprintf(brokerIntegrationsBasePath+"/integrations", tenantID, connectionID), opts)
+	path, err := restPath(fmt.Sprintf(brokerIntegrationsBasePath+"/integrations", tenantID, connectionID), brokersAPIVersion, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1754,8 +1722,7 @@ func (s *BrokersService) CreateIntegration(ctx context.Context, tenantID, connec
 		return nil, nil, errors.New("failed to create broker integration: payload must be supplied")
 	}
 
-	opts := BaseOptions{Version: brokersAPIVersion}
-	path, err := addOptions(fmt.Sprintf(brokerIntegrationsBasePath+"/orgs/%v/integration", tenantID, connectionID, orgID), opts)
+	path, err := restPath(fmt.Sprintf(brokerIntegrationsBasePath+"/orgs/%v/integration", tenantID, connectionID, orgID), brokersAPIVersion, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1800,9 +1767,7 @@ func (s *BrokersService) DeleteIntegration(ctx context.Context, tenantID, connec
 		return nil, errors.New("failed to create delete integration: integration id must be supplied")
 	}
 
-	opts := BaseOptions{Version: brokersAPIVersion}
-
-	path, err := addOptions(fmt.Sprintf(brokerIntegrationsBasePath+"/orgs/%v/integrations/%v", tenantID, connectionID, orgID, integrationID), opts)
+	path, err := restPath(fmt.Sprintf(brokerIntegrationsBasePath+"/orgs/%v/integrations/%v", tenantID, connectionID, orgID, integrationID), brokersAPIVersion, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/snyk/brokers_test.go
+++ b/snyk/brokers_test.go
@@ -14,6 +14,7 @@ func TestBrokers_ListDeployments(t *testing.T) {
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/installs/install-id/deployments", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
+		assertRequestAPIVersion(t, r, brokersAPIVersion)
 		_, _ = fmt.Fprint(w, `
 {
   "jsonapi": { "version": "1.0" },
@@ -70,6 +71,7 @@ func TestBrokers_ListDeploymentsForTenant(t *testing.T) {
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/deployments", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
+		assertRequestAPIVersion(t, r, brokersAPIVersion)
 		_, _ = fmt.Fprint(w, `
 {
   "jsonapi": { "version": "1.0" },
@@ -119,6 +121,7 @@ func TestBrokers_CreateDeployment(t *testing.T) {
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/installs/install-id/deployments", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
+		assertRequestAPIVersion(t, r, brokersAPIVersion)
 		_, _ = fmt.Fprint(w, `
 {
   "jsonapi": { "version": "1.0" },
@@ -180,6 +183,7 @@ func TestBrokers_UpdateDeployment(t *testing.T) {
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/installs/install-id/deployments/deployment-id", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPatch, r.Method)
+		assertRequestAPIVersion(t, r, brokersAPIVersion)
 		_, _ = fmt.Fprint(w, `
 {
   "jsonapi": { "version": "1.0" },
@@ -248,6 +252,7 @@ func TestBrokers_DeleteDeployment(t *testing.T) {
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/installs/install-id/deployments/deployment-id", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodDelete, r.Method)
+		assertRequestAPIVersion(t, r, brokersAPIVersion)
 	})
 
 	_, err := client.Brokers.DeleteDeployment(ctx, "tenant-id", "install-id", "deployment-id")
@@ -282,6 +287,7 @@ func TestBrokers_ListDeploymentCredentials(t *testing.T) {
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/installs/install-id/deployments/deployment-id/credentials", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
+		assertRequestAPIVersion(t, r, brokersAPIVersion)
 		_, _ = fmt.Fprint(w, `
 {
   "jsonapi": { "version": "1.0" },
@@ -368,6 +374,7 @@ func TestBrokers_GetDeploymentCredential(t *testing.T) {
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/installs/install-id/deployments/deployment-id/credentials/credential-id", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
+		assertRequestAPIVersion(t, r, brokersAPIVersion)
 		_, _ = fmt.Fprint(w, `
 {
   "jsonapi": { "version": "1.0" },
@@ -439,6 +446,7 @@ func TestBrokers_CreateDeploymentCredential(t *testing.T) {
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/installs/install-id/deployments/deployment-id/credentials", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
+		assertRequestAPIVersion(t, r, brokersAPIVersion)
 		_, _ = fmt.Fprint(w, `
 {
   "jsonapi": { "version": "1.0" },
@@ -515,6 +523,7 @@ func TestBrokers_UpdateDeploymentCredential(t *testing.T) {
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/installs/install-id/deployments/deployment-id/credentials/credential-id", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPatch, r.Method)
+		assertRequestAPIVersion(t, r, brokersAPIVersion)
 		_, _ = fmt.Fprint(w, `
 {
   "jsonapi": { "version": "1.0" },
@@ -596,6 +605,7 @@ func TestBrokers_DeleteDeploymentCredential(t *testing.T) {
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/installs/install-id/deployments/deployment-id/credentials/credential-id", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodDelete, r.Method)
+		assertRequestAPIVersion(t, r, brokersAPIVersion)
 	})
 
 	_, err := client.Brokers.DeleteDeploymentCredential(ctx, "tenant-id", "install-id", "deployment-id", "credential-id")
@@ -637,6 +647,7 @@ func TestBrokers_ListConnections(t *testing.T) {
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/installs/install-id/deployments/deployment-id/connections", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
+		assertRequestAPIVersion(t, r, brokersAPIVersion)
 		_, _ = fmt.Fprint(w, `
 {
   "jsonapi": { "version": "1.0" },
@@ -711,6 +722,7 @@ func TestBrokers_GetConnection(t *testing.T) {
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/installs/install-id/deployments/deployment-id/connections/connection-id", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
+		assertRequestAPIVersion(t, r, brokersAPIVersion)
 		_, _ = fmt.Fprint(w, `
 {
   "jsonapi": { "version": "1.0" },
@@ -785,6 +797,7 @@ func TestBrokers_CreateConnection(t *testing.T) {
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/installs/install-id/deployments/deployment-id/connections", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
+		assertRequestAPIVersion(t, r, brokersAPIVersion)
 		_, _ = fmt.Fprint(w, `
 {
   "jsonapi": { "version": "1.0" },
@@ -871,6 +884,7 @@ func TestBrokers_UpdateConnection(t *testing.T) {
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/installs/install-id/deployments/deployment-id/connections/connection-id", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPatch, r.Method)
+		assertRequestAPIVersion(t, r, brokersAPIVersion)
 		_, _ = fmt.Fprint(w, `
 {
   "jsonapi": { "version": "1.0" },
@@ -964,6 +978,7 @@ func TestBrokers_DeleteConnection(t *testing.T) {
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/installs/install-id/deployments/deployment-id/connections/connection-id", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodDelete, r.Method)
+		assertRequestAPIVersion(t, r, brokersAPIVersion)
 	})
 
 	_, err := client.Brokers.DeleteConnection(ctx, "tenant-id", "install-id", "deployment-id", "connection-id")
@@ -1011,6 +1026,7 @@ func TestBrokers_ListIntegrations(t *testing.T) {
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/connections/connection-id/integrations", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
+		assertRequestAPIVersion(t, r, brokersAPIVersion)
 		_, _ = fmt.Fprint(w, `
 {
   "jsonapi": { "version": "1.0" },
@@ -1062,6 +1078,7 @@ func TestBrokers_CreateIntegration(t *testing.T) {
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/connections/connection-id/orgs/org-id/integration", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodPost, r.Method)
+		assertRequestAPIVersion(t, r, brokersAPIVersion)
 		_, _ = fmt.Fprint(w, `
 {
   "jsonapi": { "version": "1.0" },
@@ -1125,6 +1142,7 @@ func TestBrokers_DeleteIntegration(t *testing.T) {
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/connections/connection-id/orgs/org-id/integrations/integration-id", func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodDelete, r.Method)
+		assertRequestAPIVersion(t, r, brokersAPIVersion)
 	})
 
 	_, err := client.Brokers.DeleteIntegration(ctx, "tenant-id", "connection-id", "org-id", "integration-id")

--- a/snyk/client.go
+++ b/snyk/client.go
@@ -24,7 +24,8 @@ const (
 	restAPIMediaType = "application/vnd.api+json"
 	defaultUserAgent = "snyk-sdk-go/" + libraryVersion + " (+https://github.com/pavel-snyk/snyk-sdk-go)"
 
-	headerSnykRequestID = "snyk-request-id"
+	headerSnykRequestID     = "snyk-request-id"
+	headerSnykVersionServed = "snyk-version-served"
 )
 
 // A Client manages communication with the Snyk API.
@@ -98,15 +99,8 @@ type service struct {
 	client *Client
 }
 
-type BaseOptions struct {
-	// The requested API version. This query parameter is required.
-	Version string `url:"version"`
-}
-
 // ListOptions specifies the optional parameters to various List methods.
 type ListOptions struct {
-	BaseOptions
-
 	// The page of results immediately after this cursor.
 	StartingAfter string `url:"starting_after,omitempty"`
 
@@ -117,8 +111,36 @@ type ListOptions struct {
 	Limit int `url:"limit,omitempty"`
 }
 
+// restPath builds a REST endpoint path with its required API version and optional query parameters.
+// opts may be nil or a typed nil pointer.
+func restPath(endpoint, version string, opts any) (string, error) {
+	if version == "" {
+		return "", fmt.Errorf("API version is required for endpoint %q", endpoint)
+	}
+
+	path := endpoint
+	if opts != nil {
+		var err error
+		path, err = addOptions(endpoint, opts)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	u, err := url.Parse(path)
+	if err != nil {
+		return "", err
+	}
+
+	qs := u.Query()
+	qs.Set("version", version)
+	u.RawQuery = qs.Encode()
+
+	return u.String(), nil
+}
+
 // addOptions adds the parameters in opts as URL query parameters to s.
-// opts must be a struct whose  fields may contain "url" tags.
+// opts must be a struct whose fields may contain "url" tags.
 func addOptions(s string, opts any) (string, error) {
 	v := reflect.ValueOf(opts)
 	if v.Kind() == reflect.Ptr && v.IsNil() {
@@ -325,18 +347,28 @@ type Response struct {
 	Links *PaginatedLinks
 
 	SnykRequestID string // SnykRequestID returned from the API, useful to contact support.
+
+	// ServedAPIVersion is the endpoint-specific API version selected by Snyk.
+	ServedAPIVersion string
 }
 
 // newResponse creates a new Response for the provided http.Response. r must be not nil.
 func newResponse(r *http.Response) *Response {
 	response := &Response{Response: r}
 	response.populateSnykRequestID()
+	response.populateServedAPIVersion()
 	return response
 }
 
 func (r *Response) populateSnykRequestID() {
 	if snykRequestID := r.Header.Get(headerSnykRequestID); snykRequestID != "" {
 		r.SnykRequestID = snykRequestID
+	}
+}
+
+func (r *Response) populateServedAPIVersion() {
+	if servedAPIVersion := r.Header.Get(headerSnykVersionServed); servedAPIVersion != "" {
+		r.ServedAPIVersion = servedAPIVersion
 	}
 }
 

--- a/snyk/client_test.go
+++ b/snyk/client_test.go
@@ -86,3 +86,106 @@ func TestClient_NewClient_withUserAgent(t *testing.T) {
 	assert.NotNil(t, client)
 	assert.Equal(t, "test-user-agent", client.userAgent)
 }
+
+func TestClient_restPath(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]struct {
+		endpoint        string
+		version         string
+		opts            any
+		expectedPath    string
+		expectedQueries url.Values
+		errorExpected   bool
+	}{
+		"version-only": {
+			endpoint:        "projects",
+			version:         "2025-11-05",
+			expectedPath:    "projects",
+			expectedQueries: url.Values{"version": {"2025-11-05"}},
+		},
+		"typed-nil-options": {
+			endpoint:        "projects",
+			version:         "2025-11-05",
+			opts:            (*ListOptions)(nil),
+			expectedPath:    "projects",
+			expectedQueries: url.Values{"version": {"2025-11-05"}},
+		},
+		"list-options": {
+			endpoint:     "projects",
+			version:      "2025-11-05",
+			opts:         &ListOptions{StartingAfter: "cursor", Limit: 25},
+			expectedPath: "projects",
+			expectedQueries: url.Values{
+				"limit":          {"25"},
+				"starting_after": {"cursor"},
+				"version":        {"2025-11-05"},
+			},
+		},
+		"preserves-existing-query": {
+			endpoint:     "projects?expand=target&version=caller-value",
+			version:      "2025-11-05",
+			expectedPath: "projects",
+			expectedQueries: url.Values{
+				"expand":  {"target"},
+				"version": {"2025-11-05"},
+			},
+		},
+		"empty-version": {
+			endpoint:      "projects",
+			errorExpected: true,
+		},
+		"malformed-endpoint": {
+			endpoint:      "://projects",
+			version:       "2025-11-05",
+			errorExpected: true,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			path, err := restPath(test.endpoint, test.version, test.opts)
+			if test.errorExpected {
+				assert.Error(t, err)
+				return
+			}
+
+			if !assert.NoError(t, err) {
+				return
+			}
+			parsedPath, err := url.Parse(path)
+			if !assert.NoError(t, err) {
+				return
+			}
+			assert.Equal(t, test.expectedPath, parsedPath.Path)
+			assert.Equal(t, test.expectedQueries, parsedPath.Query())
+		})
+	}
+}
+
+func TestClient_newResponse_populatesServedAPIVersion(t *testing.T) {
+	t.Parallel()
+
+	header := make(http.Header)
+	header.Set(headerSnykVersionServed, "2023-01-30~beta")
+	httpResponse := &http.Response{Header: header}
+
+	response := newResponse(httpResponse)
+	errorResponse := &ErrorResponse{Response: response}
+
+	assert.Equal(t, "2023-01-30~beta", response.ServedAPIVersion)
+	assert.Equal(t, response.ServedAPIVersion, errorResponse.Response.ServedAPIVersion)
+}
+
+func TestClient_newResponse_withoutServedAPIVersion(t *testing.T) {
+	t.Parallel()
+
+	response := newResponse(&http.Response{Header: make(http.Header)})
+
+	assert.Empty(t, response.ServedAPIVersion)
+}
+
+func assertRequestAPIVersion(t *testing.T, r *http.Request, expected string) {
+	t.Helper()
+	assert.Equal(t, []string{expected}, r.URL.Query()["version"])
+}

--- a/snyk/groups.go
+++ b/snyk/groups.go
@@ -85,11 +85,8 @@ func (s *GroupsService) List(ctx context.Context, opts *ListOptions) ([]Group, *
 	if opts == nil {
 		opts = &ListOptions{}
 	}
-	if opts.Version == "" {
-		opts.Version = groupsAPIVersion
-	}
 
-	path, err := addOptions(groupsBasePath, opts)
+	path, err := restPath(groupsBasePath, groupsAPIVersion, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -115,10 +112,7 @@ func (s *GroupsService) All(ctx context.Context, opts *ListOptions) (iter.Seq2[G
 	if opts == nil {
 		opts = &ListOptions{}
 	}
-	if opts.Version == "" {
-		opts.Version = groupsAPIVersion
-	}
-	return newPaginator[Group](ctx, s.client, s.client.restBaseURL, groupsBasePath, opts)
+	return newPaginator[Group](ctx, s.client, s.client.restBaseURL, groupsBasePath, groupsAPIVersion, opts)
 }
 
 func (s *GroupsService) Get(ctx context.Context, groupID string) (*Group, *Response, error) {
@@ -126,9 +120,7 @@ func (s *GroupsService) Get(ctx context.Context, groupID string) (*Group, *Respo
 		return nil, nil, errors.New("failed to get org: id must be supplied")
 	}
 
-	opts := &BaseOptions{Version: groupsAPIVersion}
-
-	path, err := addOptions(fmt.Sprintf("%v/%v", groupsBasePath, groupID), opts)
+	path, err := restPath(fmt.Sprintf("%v/%v", groupsBasePath, groupID), groupsAPIVersion, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/snyk/groups_test.go
+++ b/snyk/groups_test.go
@@ -1,0 +1,46 @@
+package snyk
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGroups_All(t *testing.T) {
+	setup()
+	defer teardown()
+
+	requestCount := 0
+	mux.HandleFunc("/groups", func(w http.ResponseWriter, r *http.Request) {
+		assertRequestAPIVersion(t, r, groupsAPIVersion)
+		requestCount++
+		switch requestCount {
+		case 1:
+			assert.Empty(t, r.URL.Query().Get("starting_after"))
+			_, _ = fmt.Fprint(w, `{
+  "data":[{"id":"group-1","type":"group","attributes":{"name":"First"}}],
+  "links":{"next":"/groups?version=server-value&starting_after=cursor-1"}
+}`)
+		case 2:
+			assert.Equal(t, "cursor-1", r.URL.Query().Get("starting_after"))
+			_, _ = fmt.Fprint(w, `{
+  "data":[{"id":"group-2","type":"group","attributes":{"name":"Second"}}],
+  "links":{}
+}`)
+		default:
+			http.Error(w, "unexpected pagination request", http.StatusInternalServerError)
+		}
+	})
+
+	seq, iterErr := client.Groups.All(ctx, nil)
+	var groupIDs []string
+	for group := range seq {
+		groupIDs = append(groupIDs, group.ID)
+	}
+
+	assert.NoError(t, iterErr())
+	assert.Equal(t, 2, requestCount)
+	assert.Equal(t, []string{"group-1", "group-2"}, groupIDs)
+}

--- a/snyk/orgs.go
+++ b/snyk/orgs.go
@@ -101,11 +101,8 @@ func (s *OrgsService) ListAccessibleOrgs(ctx context.Context, opts *ListOrganiza
 	if opts == nil {
 		opts = &ListOrganizationOptions{}
 	}
-	if opts.Version == "" {
-		opts.Version = orgsAPIVersion
-	}
 
-	path, err := addOptions(orgsBasePath, opts)
+	path, err := restPath(orgsBasePath, orgsAPIVersion, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -131,10 +128,7 @@ func (s *OrgsService) AllAccessibleOrgs(ctx context.Context, opts *ListOptions) 
 	if opts == nil {
 		opts = &ListOptions{}
 	}
-	if opts.Version == "" {
-		opts.Version = orgsAPIVersion
-	}
-	return newPaginator[Organization](ctx, s.client, s.client.restBaseURL, orgsBasePath, opts)
+	return newPaginator[Organization](ctx, s.client, s.client.restBaseURL, orgsBasePath, orgsAPIVersion, opts)
 }
 
 func (s *OrgsService) Get(ctx context.Context, orgID string, opts *GetOrganizationOptions) (*Organization, *Response, error) {
@@ -145,9 +139,8 @@ func (s *OrgsService) Get(ctx context.Context, orgID string, opts *GetOrganizati
 	if opts == nil {
 		opts = &GetOrganizationOptions{Expand: "tenant"}
 	}
-	opts.Version = orgsAPIVersion
 
-	path, err := addOptions(fmt.Sprintf("%v/%v", orgsBasePath, orgID), opts)
+	path, err := restPath(fmt.Sprintf("%v/%v", orgsBasePath, orgID), orgsAPIVersion, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -174,8 +167,7 @@ func (s *OrgsService) Update(ctx context.Context, orgID string, updateRequest *O
 		return nil, nil, errors.New("failed to update org: payload must be supplied")
 	}
 
-	opts := &ListOptions{BaseOptions: BaseOptions{Version: orgsAPIVersion}}
-	path, err := addOptions(fmt.Sprintf("%v/%v", orgsBasePath, orgID), opts)
+	path, err := restPath(fmt.Sprintf("%v/%v", orgsBasePath, orgID), orgsAPIVersion, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/snyk/orgs_test.go
+++ b/snyk/orgs_test.go
@@ -1,0 +1,28 @@
+package snyk
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOrgs_ListAccessibleOrgs(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs", func(w http.ResponseWriter, r *http.Request) {
+		assertRequestAPIVersion(t, r, orgsAPIVersion)
+		assert.Equal(t, "20", r.URL.Query().Get("limit"))
+		w.Header().Set(headerSnykVersionServed, "2024-02-28")
+		_, _ = fmt.Fprint(w, `{"data":[],"links":{}}`)
+	})
+
+	_, response, err := client.Orgs.ListAccessibleOrgs(ctx, &ListOrganizationOptions{
+		ListOptions: ListOptions{Limit: 20},
+	})
+
+	assert.NoError(t, err)
+	assert.Equal(t, "2024-02-28", response.ServedAPIVersion)
+}

--- a/snyk/paginator.go
+++ b/snyk/paginator.go
@@ -16,15 +16,13 @@ type paginatedResponse[T any] struct {
 	Links *PaginatedLinks `json:"links"`
 }
 
-func newPaginator[T any](ctx context.Context, client *Client, baseURL *url.URL, endpointURL string, opts *ListOptions) (iter.Seq2[T, *Response], func() error) {
+func newPaginator[T any](ctx context.Context, client *Client, baseURL *url.URL, endpointURL, version string, opts *ListOptions) (iter.Seq2[T, *Response], func() error) {
 	var iterErr error
+	if opts == nil {
+		opts = &ListOptions{}
+	}
 
 	seq := func(yield func(item T, resp *Response) bool) {
-		if opts == nil {
-			iterErr = fmt.Errorf("ListOptions cannot be nil, API version is required for endpoint %q", endpointURL)
-			return
-		}
-
 		for {
 			select {
 			// if the context has been canceled, the context's error is more useful
@@ -34,7 +32,7 @@ func newPaginator[T any](ctx context.Context, client *Client, baseURL *url.URL, 
 			default:
 			}
 
-			path, err := addOptions(endpointURL, opts)
+			path, err := restPath(endpointURL, version, opts)
 			if err != nil {
 				iterErr = fmt.Errorf("failed to construct URL with options: %w", err)
 				return

--- a/snyk/projects.go
+++ b/snyk/projects.go
@@ -75,9 +75,8 @@ func (s *ProjectsService) List(ctx context.Context, orgID string, opts *ListProj
 	if opts == nil {
 		opts = &ListProjectsOptions{ListOptions: ListOptions{Limit: 100}}
 	}
-	opts.Version = projectsAPIVersion
 
-	path, err := addOptions(fmt.Sprintf(projectsBaseBase, orgID), opts)
+	path, err := restPath(fmt.Sprintf(projectsBaseBase, orgID), projectsAPIVersion, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -107,9 +106,7 @@ func (s *ProjectsService) Get(ctx context.Context, orgID, projectID string) (*Pr
 		return nil, nil, errors.New("projectID must be supplied")
 	}
 
-	opts := BaseOptions{Version: projectsAPIVersion}
-
-	path, err := addOptions(fmt.Sprintf(projectsBaseBase+"/%v", orgID, projectID), opts)
+	path, err := restPath(fmt.Sprintf(projectsBaseBase+"/%v", orgID, projectID), projectsAPIVersion, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/snyk/projects_test.go
+++ b/snyk/projects_test.go
@@ -14,6 +14,7 @@ func TestProject_List(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/orgs/org-id/projects", func(w http.ResponseWriter, r *http.Request) {
+		assertRequestAPIVersion(t, r, projectsAPIVersion)
 		_, _ = fmt.Fprint(w, `
 {
   "jsonapi": { "version": "1.0" },
@@ -95,6 +96,7 @@ func TestProject_Get(t *testing.T) {
 	defer teardown()
 
 	mux.HandleFunc("/orgs/org-id/projects/project-id", func(w http.ResponseWriter, r *http.Request) {
+		assertRequestAPIVersion(t, r, projectsAPIVersion)
 		_, _ = fmt.Fprint(w, `
 {
   "jsonapi": { "version": "1.0" },

--- a/snyk/users.go
+++ b/snyk/users.go
@@ -47,9 +47,7 @@ type userRoot struct {
 func (u User) String() string { return Stringify(u) }
 
 func (s *UsersService) GetSelf(ctx context.Context) (*User, *Response, error) {
-	opts := &BaseOptions{Version: usersAPIVersion}
-
-	path, err := addOptions("self", opts)
+	path, err := restPath("self", usersAPIVersion, nil)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/snyk/users_test.go
+++ b/snyk/users_test.go
@@ -1,5 +1,13 @@
 package snyk
 
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
 //
 //import (
 //	"fmt"
@@ -34,6 +42,24 @@ package snyk
 //	assert.NoError(t, err)
 //	assert.Equal(t, expectedUser, actualUser)
 //}
+
+func TestUsers_GetSelf(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/self", func(w http.ResponseWriter, r *http.Request) {
+		assertRequestAPIVersion(t, r, usersAPIVersion)
+		_, _ = fmt.Fprint(w, `{
+  "data":{"id":"user-id","type":"user","attributes":{"name":"Test User"}}
+}`)
+	})
+
+	user, _, err := client.Users.GetSelf(ctx)
+
+	assert.NoError(t, err)
+	assert.Equal(t, "user-id", user.ID)
+}
+
 //
 //func TestUsers_Get(t *testing.T) {
 //	setup()


### PR DESCRIPTION
API version is no longer caller-supplied. Each service injects its hardcoded version internally via `restPath`, including paginated requests. Versions are now bumped deliberately as part of an SDK release.

Breaking change (pre-v2, no known external consumers):

- Removed `BaseOptions` and `ListOptions.Version`.
- Callers should remove `BaseOptions{Version: ...}`; the SDK now handles it automatically.

Added Response.ServedAPIVersion, populated from snyk-version-served, so callers can observe the endpoint contract Snyk resolved.

Version constants remain unchanged; date updates are a separate follow-up.