### PR TITLE
fix(client): reject queries and fragments in REST paths

### DIFF
--- a/snyk/client.go
+++ b/snyk/client.go
@@ -118,18 +118,23 @@ func restPath(endpoint, version string, opts any) (string, error) {
 		return "", fmt.Errorf("API version is required for endpoint %q", endpoint)
 	}
 
-	path := endpoint
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "", err
+	}
+	if u.RawQuery != "" || u.Fragment != "" {
+		return "", fmt.Errorf("REST endpoint %q must not contain a query or fragment", endpoint)
+	}
+
 	if opts != nil {
-		var err error
-		path, err = addOptions(endpoint, opts)
+		path, err := addOptions(endpoint, opts)
 		if err != nil {
 			return "", err
 		}
-	}
-
-	u, err := url.Parse(path)
-	if err != nil {
-		return "", err
+		u, err = url.Parse(path)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	qs := u.Query()

--- a/snyk/client_test.go
+++ b/snyk/client_test.go
@@ -96,7 +96,7 @@ func TestClient_restPath(t *testing.T) {
 		opts            any
 		expectedPath    string
 		expectedQueries url.Values
-		errorExpected   bool
+		expectedError   string
 	}{
 		"version-only": {
 			endpoint:        "projects",
@@ -122,31 +122,32 @@ func TestClient_restPath(t *testing.T) {
 				"version":        {"2025-11-05"},
 			},
 		},
-		"preserves-existing-query": {
-			endpoint:     "projects?expand=target&version=caller-value",
-			version:      "2025-11-05",
-			expectedPath: "projects",
-			expectedQueries: url.Values{
-				"expand":  {"target"},
-				"version": {"2025-11-05"},
-			},
+		"rejects-endpoint-query": {
+			endpoint:      "projects?version=caller-value",
+			version:       "2025-11-05",
+			expectedError: "must not contain a query or fragment",
+		},
+		"rejects-endpoint-fragment": {
+			endpoint:      "projects#section",
+			version:       "2025-11-05",
+			expectedError: "must not contain a query or fragment",
 		},
 		"empty-version": {
 			endpoint:      "projects",
-			errorExpected: true,
+			expectedError: "API version is required",
 		},
 		"malformed-endpoint": {
 			endpoint:      "://projects",
 			version:       "2025-11-05",
-			errorExpected: true,
+			expectedError: "missing protocol scheme",
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			path, err := restPath(test.endpoint, test.version, test.opts)
-			if test.errorExpected {
-				assert.Error(t, err)
+			if test.expectedError != "" {
+				assert.ErrorContains(t, err, test.expectedError)
 				return
 			}
 

--- a/snyk/orgs_test.go
+++ b/snyk/orgs_test.go
@@ -14,13 +14,18 @@ func TestOrgs_ListAccessibleOrgs(t *testing.T) {
 
 	mux.HandleFunc("/orgs", func(w http.ResponseWriter, r *http.Request) {
 		assertRequestAPIVersion(t, r, orgsAPIVersion)
+		assert.Equal(t, "cursor", r.URL.Query().Get("starting_after"))
 		assert.Equal(t, "20", r.URL.Query().Get("limit"))
+		assert.Equal(t, "group-id", r.URL.Query().Get("group_id"))
+		assert.Equal(t, "tenant", r.URL.Query().Get("expand"))
 		w.Header().Set(headerSnykVersionServed, "2024-02-28")
 		_, _ = fmt.Fprint(w, `{"data":[],"links":{}}`)
 	})
 
 	_, response, err := client.Orgs.ListAccessibleOrgs(ctx, &ListOrganizationOptions{
-		ListOptions: ListOptions{Limit: 20},
+		ListOptions: ListOptions{StartingAfter: "cursor", Limit: 20},
+		GroupID:     "group-id",
+		Expand:      "tenant",
 	})
 
 	assert.NoError(t, err)


### PR DESCRIPTION
This PR adds a check to reject queries and fragments in `restPath`