### PR TITLE
fix(client): change incorrect rest base url for eu region

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,11 @@ go get github.com/pavel-snyk/snyk-sdk-go/v2
 ## Usage
 
 ```go
-import "github.com/pavel-snyk/snyk-sdk-go/v2"
+import (
+	"log"
+
+	"github.com/pavel-snyk/snyk-sdk-go/v2/snyk"
+)
 ```
 
 Create a new Snyk client, then use the exposed services to access different
@@ -37,5 +41,8 @@ in your General Account Settings on https://snyk.io/account/ after you register
 with Snyk and log in. See [Authentication for API](https://docs.snyk.io/snyk-api-info/authentication-for-api).
 
 ```go
-client := snyk.NewClient("your-api-token")
+client, err := snyk.NewClient("your-api-token")
+if err != nil {
+	log.Fatal(err)
+}
 ```

--- a/snyk/client.go
+++ b/snyk/client.go
@@ -77,7 +77,7 @@ var regions = []Region{
 	{
 		Alias:       "SNYK-EU-01",
 		AppBaseURL:  "https://app.eu.snyk.io/",
-		RESTBaseURL: "https://app.eu.snyk.io/rest/",
+		RESTBaseURL: "https://api.eu.snyk.io/rest/",
 		V1BaseURL:   "https://api.eu.snyk.io/v1/",
 	},
 	{

--- a/snyk/client_test.go
+++ b/snyk/client_test.go
@@ -37,6 +37,63 @@ func teardown() {
 	server.Close()
 }
 
+func TestClient_Regions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		expected Region
+	}{
+		{
+			name: "SNYK-US-01",
+			expected: Region{
+				Alias:       "SNYK-US-01",
+				AppBaseURL:  "https://app.snyk.io/",
+				RESTBaseURL: "https://api.snyk.io/rest/",
+				V1BaseURL:   "https://api.snyk.io/v1/",
+			},
+		},
+		{
+			name: "SNYK-US-02",
+			expected: Region{
+				Alias:       "SNYK-US-02",
+				AppBaseURL:  "https://app.us.snyk.io/",
+				RESTBaseURL: "https://api.us.snyk.io/rest/",
+				V1BaseURL:   "https://api.us.snyk.io/v1/",
+			},
+		},
+		{
+			name: "SNYK-EU-01",
+			expected: Region{
+				Alias:       "SNYK-EU-01",
+				AppBaseURL:  "https://app.eu.snyk.io/",
+				RESTBaseURL: "https://api.eu.snyk.io/rest/",
+				V1BaseURL:   "https://api.eu.snyk.io/v1/",
+			},
+		},
+		{
+			name: "SNYK-AU-01",
+			expected: Region{
+				Alias:       "SNYK-AU-01",
+				AppBaseURL:  "https://app.au.snyk.io/",
+				RESTBaseURL: "https://api.au.snyk.io/rest/",
+				V1BaseURL:   "https://api.au.snyk.io/v1/",
+			},
+		},
+	}
+
+	actualRegions := Regions()
+	if !assert.Len(t, actualRegions, len(tests)) {
+		return
+	}
+
+	for i, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, actualRegions[i])
+		})
+	}
+}
+
 func TestClient_NewClient_defaults(t *testing.T) {
 	client, err := NewClient("auth-token")
 

--- a/snyk/client_test.go
+++ b/snyk/client_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -83,9 +84,7 @@ func TestClient_Regions(t *testing.T) {
 	}
 
 	actualRegions := Regions()
-	if !assert.Len(t, actualRegions, len(tests)) {
-		return
-	}
+	require.Len(t, actualRegions, len(tests))
 
 	for i, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
This PR fixes incorrect `RestBaseURL` for SNYK-EU-1 region + small doc improvements in readme how to use the client.