### PR TITLE
feat(projects): establish projects paved path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,6 +80,36 @@ them in a PR.
 - Expose services from `Client` as concrete pointers. Do not define SDK-owned
   service interfaces. Consumers define narrow interfaces containing only the
   SDK operations they use, including for mocking.
+- Name new operation-specific public types with the resource first so related
+  APIs group in autocomplete, for example `ProjectListOptions`,
+  `ProjectCreateRequest`, and `ProjectUpdateRequest`.
+
+### 4.1 Test Fixtures
+
+Store large or realistic response fixtures in `snyk/testdata`, normally
+using lowercase snake-case names of the form:
+
+```text
+<service>_<method>_<scenario>.json
+```
+
+For example:
+
+```text
+projects_get_success.json
+projects_get_expanded_target.json
+projects_all_page_2.json
+```
+
+Always include a scenario. Use `success` for the ordinary happy path and
+a more specific scenario when it communicates more, such as
+`expanded_target` or `not_found`.
+
+Keep small, test-specific response bodies inline when that is clearer.
+Use unmistakably synthetic fixture data, such as repeated-digit UUIDs and
+clearly fictional resource names. Never copy customer or production data.
+Load fixtures through the shared
+`loadFixture(t *testing.T, fixtureName string) []byte` test helper.
 
 ## 5. Adding a New Service (checklist)
 
@@ -114,3 +144,15 @@ from `client.X`.
 
 - Run `make test` for the full test suite and coverage report.
 - Run `make lint` before considering implementation work complete.
+
+## 7. Service File Organization
+
+Keep service files readable from top to bottom: service declarations and
+primary public types first, followed by private transport types, primary
+service methods, and related mapping and helper functions.
+
+Keep methods such as `String` close to the public model they belong to.
+
+Keep public and private types, methods, and helpers used only by a secondary
+endpoint group near that group. Treat this as a readability guideline, not a
+reason to mechanically reorder existing files or create unrelated churn.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -34,3 +34,29 @@ func NewHandler(projects ProjectGetter) *Handler {
 Production code can pass `client.Projects`; tests can pass a consumer-owned
 fake. Testability therefore lives at the consumer's dependency boundary rather
 than by replacing fields inside the SDK client.
+
+## Project is an SDK read model
+
+`Project` is now a flat, SDK-owned read model rather than a public mirror of
+the REST JSON:API resource. `ProjectAttributes` has been removed. Code that
+previously read fields through `project.Attributes` must use the corresponding
+fields directly on `Project`.
+
+The SDK's JSON field names for `Project` are also distinct from the REST wire
+representation and form part of the v2 public contract.
+
+## Project iteration
+
+`ProjectsService.All` accepts `*ProjectListOptions`, so the same filters used
+for one page can be preserved across every page. The options are deeply
+snapshotted when `All` is called.
+
+`ProjectsService.List` no longer supplies an SDK default limit of 100 when its
+options are nil. It now omits the limit and uses the endpoint's server-defined
+default, like other REST list operations.
+
+Iteration is forward-only: an ending-before cursor is rejected. Each page is
+converted atomically, so a malformed page yields none of its Projects while
+Projects from previously completed pages remain yielded. The returned sequence
+may be iterated multiple times sequentially, but concurrent or overlapping
+iteration is not supported.

--- a/snyk/apps_test.go
+++ b/snyk/apps_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestApps_DeleteAppInstallFromOrg(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/orgs/org-id/apps/installs/install-id", func(w http.ResponseWriter, r *http.Request) {

--- a/snyk/brokers_test.go
+++ b/snyk/brokers_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestBrokers_ListDeployments(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/installs/install-id/deployments", func(w http.ResponseWriter, r *http.Request) {
@@ -66,7 +66,7 @@ func TestBrokers_ListDeployments_emptyAppInstallID(t *testing.T) {
 }
 
 func TestBrokers_ListDeploymentsForTenant(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/deployments", func(w http.ResponseWriter, r *http.Request) {
@@ -116,7 +116,7 @@ func TestBrokers_ListDeploymentsForTenant_emptyTenantID(t *testing.T) {
 }
 
 func TestBrokers_CreateDeployment(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/installs/install-id/deployments", func(w http.ResponseWriter, r *http.Request) {
@@ -178,7 +178,7 @@ func TestBrokers_CreateDeployment_emptyPayload(t *testing.T) {
 }
 
 func TestBrokers_UpdateDeployment(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/installs/install-id/deployments/deployment-id", func(w http.ResponseWriter, r *http.Request) {
@@ -247,7 +247,7 @@ func TestBrokers_UpdateDeployment_emptyPayload(t *testing.T) {
 }
 
 func TestBrokers_DeleteDeployment(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/installs/install-id/deployments/deployment-id", func(w http.ResponseWriter, r *http.Request) {
@@ -282,7 +282,7 @@ func TestBrokers_DeleteDeployment_emptyDeploymentID(t *testing.T) {
 }
 
 func TestBrokers_ListDeploymentCredentials(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/installs/install-id/deployments/deployment-id/credentials", func(w http.ResponseWriter, r *http.Request) {
@@ -369,7 +369,7 @@ func TestBrokers_ListDeploymentCredentials_emptyDeploymentID(t *testing.T) {
 }
 
 func TestBrokers_GetDeploymentCredential(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/installs/install-id/deployments/deployment-id/credentials/credential-id", func(w http.ResponseWriter, r *http.Request) {
@@ -441,7 +441,7 @@ func TestBrokers_GetDeploymentCredential_emptyCredentialID(t *testing.T) {
 }
 
 func TestBrokers_CreateDeploymentCredential(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/installs/install-id/deployments/deployment-id/credentials", func(w http.ResponseWriter, r *http.Request) {
@@ -518,7 +518,7 @@ func TestBrokers_CreateDeploymentCredential_emptyPayload(t *testing.T) {
 }
 
 func TestBrokers_UpdateDeploymentCredential(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/installs/install-id/deployments/deployment-id/credentials/credential-id", func(w http.ResponseWriter, r *http.Request) {
@@ -600,7 +600,7 @@ func TestBrokers_UpdateDeploymentCredential_emptyPayload(t *testing.T) {
 }
 
 func TestBrokers_DeleteDeploymentCredential(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/installs/install-id/deployments/deployment-id/credentials/credential-id", func(w http.ResponseWriter, r *http.Request) {
@@ -642,7 +642,7 @@ func TestBrokers_DeleteDeploymentCredential_emptyCredentialID(t *testing.T) {
 }
 
 func TestBrokers_ListConnections(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/installs/install-id/deployments/deployment-id/connections", func(w http.ResponseWriter, r *http.Request) {
@@ -717,7 +717,7 @@ func TestBrokers_ListConnections_emptyDeploymentID(t *testing.T) {
 }
 
 func TestBrokers_GetConnection(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/installs/install-id/deployments/deployment-id/connections/connection-id", func(w http.ResponseWriter, r *http.Request) {
@@ -792,7 +792,7 @@ func TestBrokers_GetConnection_emptyConnectionID(t *testing.T) {
 }
 
 func TestBrokers_CreateConnection(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/installs/install-id/deployments/deployment-id/connections", func(w http.ResponseWriter, r *http.Request) {
@@ -879,7 +879,7 @@ func TestBrokers_CreateConnection_emptyPayload(t *testing.T) {
 }
 
 func TestBrokers_UpdateConnection(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/installs/install-id/deployments/deployment-id/connections/connection-id", func(w http.ResponseWriter, r *http.Request) {
@@ -973,7 +973,7 @@ func TestBrokers_UpdateConnection_emptyPayload(t *testing.T) {
 }
 
 func TestBrokers_DeleteConnection(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/installs/install-id/deployments/deployment-id/connections/connection-id", func(w http.ResponseWriter, r *http.Request) {
@@ -1021,7 +1021,7 @@ func TestBrokers_buildBrokerConnectionRequestPayload_emptyPayload(t *testing.T) 
 }
 
 func TestBrokers_ListIntegrations(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/connections/connection-id/integrations", func(w http.ResponseWriter, r *http.Request) {
@@ -1073,7 +1073,7 @@ func TestBrokers_ListIntegrations_emptyConnectionID(t *testing.T) {
 }
 
 func TestBrokers_CreateIntegration(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/connections/connection-id/orgs/org-id/integration", func(w http.ResponseWriter, r *http.Request) {
@@ -1137,7 +1137,7 @@ func TestBrokers_CreateIntegration_emptyPayload(t *testing.T) {
 }
 
 func TestBrokers_DeleteIntegration(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/tenants/tenant-id/brokers/connections/connection-id/orgs/org-id/integrations/integration-id", func(w http.ResponseWriter, r *http.Request) {

--- a/snyk/client_test.go
+++ b/snyk/client_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -245,4 +247,15 @@ func TestClient_newResponse_withoutServedAPIVersion(t *testing.T) {
 func assertRequestAPIVersion(t *testing.T, r *http.Request, expected string) {
 	t.Helper()
 	assert.Equal(t, []string{expected}, r.URL.Query()["version"])
+}
+
+func loadFixture(t *testing.T, fixtureName string) []byte {
+	t.Helper()
+
+	data, err := os.ReadFile(filepath.Join("testdata", fixtureName))
+	if err != nil {
+		t.Fatalf("failed to load fixture %q: %v", fixtureName, err)
+	}
+
+	return data
 }

--- a/snyk/client_test.go
+++ b/snyk/client_test.go
@@ -2,12 +2,15 @@ package snyk
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -22,11 +25,22 @@ var (
 	server *httptest.Server
 )
 
-func setup() {
+func newTestClient(t testing.TB, options ...ClientOption) *Client {
+	t.Helper()
+
+	c, err := NewClient("auth-token", options...)
+	require.NoError(t, err)
+
+	return c
+}
+
+func setup(t testing.TB) {
+	t.Helper()
+
 	mux = http.NewServeMux()
 	server = httptest.NewServer(mux)
 
-	client, _ = NewClient("auth-token",
+	client = newTestClient(t,
 		WithRegion(Region{
 			Alias:       "TEST",
 			AppBaseURL:  fmt.Sprintf("%v/", server.URL),
@@ -222,6 +236,148 @@ func TestClient_restPath(t *testing.T) {
 	}
 }
 
+func TestClient_checkResponse(t *testing.T) {
+	tests := map[string]struct {
+		statusCode      int
+		body            string
+		wantAPIErrors   []APIError
+		wantErrContains string
+	}{
+		"success": {
+			statusCode: http.StatusOK,
+		},
+		"REST error": {
+			statusCode: http.StatusNotFound,
+			body:       `{"errors":[{"status":"404","title":"Project not found"}]}`,
+			wantAPIErrors: []APIError{{
+				StatusCode: "404",
+				Title:      "Project not found",
+			}},
+		},
+		"legacy error": {
+			statusCode: http.StatusBadRequest,
+			body:       `{"message":"Invalid request","errorRef":"fake-error-reference"}`,
+			wantAPIErrors: []APIError{{
+				Detail:     "Invalid request",
+				ID:         "fake-error-reference",
+				StatusCode: "400",
+				Title:      "Invalid request",
+			}},
+		},
+		"undecodable error": {
+			statusCode:      http.StatusInternalServerError,
+			body:            "not JSON",
+			wantErrContains: "failed to decode Snyk API error response; status: 500",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			response := createTestResponse(http.MethodGet, "https://api.snyk.io/rest/projects", test.statusCode, "")
+			response.Body = io.NopCloser(strings.NewReader(test.body))
+
+			err := checkResponse(response)
+
+			if test.statusCode == http.StatusOK {
+				require.NoError(t, err)
+				return
+			}
+			if test.wantErrContains != "" {
+				assert.ErrorContains(t, err, test.wantErrContains)
+				return
+			}
+
+			var errorResponse *ErrorResponse
+			require.ErrorAs(t, err, &errorResponse)
+			assert.Same(t, response, errorResponse.Response)
+			assert.Equal(t, test.wantAPIErrors, errorResponse.APIErrors)
+		})
+	}
+}
+
+func TestClient_do_decodesSuccessResponse(t *testing.T) {
+	c := newTestClient(t, WithHTTPClient(&http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"name":"decoded"}`)),
+			Request:    req,
+		}, nil
+	})}))
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://api.snyk.io/rest/projects", nil)
+	require.NoError(t, err)
+	destination := struct {
+		Name string `json:"name"`
+	}{Name: "original"}
+
+	response, err := c.do(context.Background(), req, &destination)
+
+	require.NoError(t, err)
+	require.NotNil(t, response)
+	assert.Equal(t, http.StatusOK, response.StatusCode)
+	assert.Equal(t, "decoded", destination.Name)
+}
+
+func TestClient_do_returnsErrorResponse(t *testing.T) {
+	c := newTestClient(t, WithHTTPClient(&http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		header := make(http.Header)
+		header.Set(headerSnykRequestID, "fake-request-id")
+		header.Set(headerSnykVersionServed, "2025-11-05")
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Header:     header,
+			Body:       io.NopCloser(strings.NewReader(`{"errors":[{"status":"404","title":"Project not found"}]}`)),
+			Request:    req,
+		}, nil
+	})}))
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://api.snyk.io/rest/projects/missing", nil)
+	require.NoError(t, err)
+	destination := struct {
+		Name string `json:"name"`
+	}{Name: "unchanged"}
+	wantDestination := destination
+
+	response, err := c.do(context.Background(), req, &destination)
+
+	require.NotNil(t, response)
+	var errorResponse *ErrorResponse
+	require.ErrorAs(t, err, &errorResponse)
+	assert.Same(t, response, errorResponse.Response)
+	assert.Equal(t, http.StatusNotFound, response.StatusCode)
+	assert.Equal(t, "fake-request-id", response.SnykRequestID)
+	assert.Equal(t, "2025-11-05", response.ServedAPIVersion)
+	assert.Equal(t, wantDestination, destination)
+}
+
+func TestClient_do_propagatesNetworkError(t *testing.T) {
+	networkErr := errors.New("network unavailable")
+	c := newTestClient(t, WithHTTPClient(&http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return nil, networkErr
+	})}))
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "https://api.snyk.io/rest/projects", nil)
+	require.NoError(t, err)
+
+	response, err := c.do(context.Background(), req, nil)
+
+	assert.Nil(t, response)
+	require.ErrorIs(t, err, networkErr)
+}
+
+func TestClient_do_prefersCanceledContextError(t *testing.T) {
+	c := newTestClient(t, WithHTTPClient(&http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("transport error")
+	})}))
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	req, err := http.NewRequestWithContext(canceledCtx, http.MethodGet, "https://api.snyk.io/rest/projects", nil)
+	require.NoError(t, err)
+
+	response, err := c.do(canceledCtx, req, nil)
+
+	assert.Nil(t, response)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
 func TestClient_newResponse_populatesServedAPIVersion(t *testing.T) {
 	t.Parallel()
 
@@ -258,4 +414,10 @@ func loadFixture(t *testing.T, fixtureName string) []byte {
 	}
 
 	return data
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
 }

--- a/snyk/errors.go
+++ b/snyk/errors.go
@@ -2,9 +2,13 @@ package snyk
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 )
+
+// ErrEmptyArgument indicates that a required SDK argument was empty.
+var ErrEmptyArgument = errors.New("argument is empty")
 
 // An ErrorResponse reports an error caused by an API request.
 type ErrorResponse struct {

--- a/snyk/errors_test.go
+++ b/snyk/errors_test.go
@@ -8,6 +8,54 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestError_parseRESTError(t *testing.T) {
+	tests := map[string]struct {
+		data      string
+		want      []APIError
+		wantValid bool
+	}{
+		"single error": {
+			data: `{"errors":[{
+				"status":"404",
+				"title":"Project not found",
+				"detail":"The requested Project does not exist"
+			}]}`,
+			want: []APIError{{
+				StatusCode: "404",
+				Title:      "Project not found",
+				Detail:     "The requested Project does not exist",
+			}},
+			wantValid: true,
+		},
+		"multiple errors": {
+			data: `{"errors":[
+				{"status":"400","title":"Invalid request"},
+				{"status":"403","detail":"Permission denied"}
+			]}`,
+			want: []APIError{
+				{StatusCode: "400", Title: "Invalid request"},
+				{StatusCode: "403", Detail: "Permission denied"},
+			},
+			wantValid: true,
+		},
+		"malformed JSON": {
+			data: `{"errors":[`,
+		},
+		"unexpected shape": {
+			data: `{"message":"Not found"}`,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			apiErrors, valid := parseRESTError([]byte(test.data))
+
+			assert.Equal(t, test.wantValid, valid)
+			assert.Equal(t, test.want, apiErrors)
+		})
+	}
+}
+
 func TestErrorResponse_Error_withoutSnykRequestID(t *testing.T) {
 	errorResponse := &ErrorResponse{
 		Response: createTestResponse(http.MethodGet, "https://api.snyk.io/rest/somepath", 401, ""),

--- a/snyk/groups.go
+++ b/snyk/groups.go
@@ -88,16 +88,22 @@ func (s *GroupsService) List(ctx context.Context, opts *ListOptions) ([]Group, *
 
 // All returns an iterator to paginate over all groups you are a member of.
 //
-// This method handles the pagination logic internally for each page.
+// This method handles the pagination logic internally by calling List for each page.
+// The returned sequence may be iterated multiple times sequentially. It is not safe
+// for concurrent or overlapping iteration.
 //
 // Note: This function is experimental and its signature may change in a future release.
 //
 // See: https://docs.snyk.io/snyk-api/reference/groups#get-groups
 func (s *GroupsService) All(ctx context.Context, opts *ListOptions) (iter.Seq2[Group, *Response], func() error) {
-	if opts == nil {
-		opts = &ListOptions{}
+	initialOptions := ListOptions{}
+	if opts != nil {
+		initialOptions = *opts
 	}
-	return newPaginator[Group](ctx, s.client, s.client.restBaseURL, groupsBasePath, groupsAPIVersion, opts)
+
+	return newPaginator(ctx, initialOptions, func(ctx context.Context, pageOptions ListOptions) ([]Group, *Response, error) {
+		return s.List(ctx, &pageOptions)
+	})
 }
 
 // Get provides the full details of a group.

--- a/snyk/groups_test.go
+++ b/snyk/groups_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestGroups_All(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	requestCount := 0

--- a/snyk/orgs.go
+++ b/snyk/orgs.go
@@ -99,16 +99,22 @@ func (s *OrgsService) ListAccessibleOrgs(ctx context.Context, opts *ListOrganiza
 
 // AllAccessibleOrgs returns an iterator over all organizations you have access to.
 //
-// This method handles the pagination logic internally for each page.
+// This method handles the pagination logic internally by calling ListAccessibleOrgs for each page.
+// The returned sequence may be iterated multiple times sequentially. It is not safe
+// for concurrent or overlapping iteration.
 //
 // Note: This function is experimental and its signature may change in a future release.
 //
 // See: https://docs.snyk.io/snyk-api/reference/orgs#get-orgs
 func (s *OrgsService) AllAccessibleOrgs(ctx context.Context, opts *ListOptions) (iter.Seq2[Organization, *Response], func() error) {
-	if opts == nil {
-		opts = &ListOptions{}
+	initialOptions := ListOptions{}
+	if opts != nil {
+		initialOptions = *opts
 	}
-	return newPaginator[Organization](ctx, s.client, s.client.restBaseURL, orgsBasePath, orgsAPIVersion, opts)
+
+	return newPaginator(ctx, initialOptions, func(ctx context.Context, pageOptions ListOptions) ([]Organization, *Response, error) {
+		return s.ListAccessibleOrgs(ctx, &ListOrganizationOptions{ListOptions: pageOptions})
+	})
 }
 
 // Get provides the full details of an organization.

--- a/snyk/orgs_test.go
+++ b/snyk/orgs_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestOrgs_ListAccessibleOrgs(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/orgs", func(w http.ResponseWriter, r *http.Request) {

--- a/snyk/paginator.go
+++ b/snyk/paginator.go
@@ -2,68 +2,49 @@ package snyk
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"iter"
-	"net/http"
 	"net/url"
 )
 
-// paginatedResponse is a generic "container" used to unmarshal any paginated list response
-// from Snyk REST API. It assumes the response body has a "data" field (according jsonapi),
-// containing a slice of items and a "links" field for pagination.
-type paginatedResponse[T any] struct {
-	Data  []T             `json:"data,omitempty"`
-	Links *PaginatedLinks `json:"links"`
-}
+type pageFetcher[T any] func(context.Context, ListOptions) ([]T, *Response, error)
 
-func newPaginator[T any](ctx context.Context, client *Client, baseURL *url.URL, endpointURL, version string, opts *ListOptions) (iter.Seq2[T, *Response], func() error) {
+func newPaginator[T any](ctx context.Context, initialOptions ListOptions, fetchPage pageFetcher[T]) (iter.Seq2[T, *Response], func() error) {
 	var iterErr error
-	if opts == nil {
-		opts = &ListOptions{}
-	}
 
 	seq := func(yield func(item T, resp *Response) bool) {
+		iterErr = nil
+		paginationOptions := initialOptions
+		seenCursors := make(map[string]struct{})
+		if paginationOptions.StartingAfter != "" {
+			seenCursors[paginationOptions.StartingAfter] = struct{}{}
+		}
+
 		for {
-			select {
-			// if the context has been canceled, the context's error is more useful
-			case <-ctx.Done():
-				iterErr = ctx.Err()
-				return
-			default:
-			}
-
-			path, err := restPath(endpointURL, version, opts)
-			if err != nil {
-				iterErr = fmt.Errorf("failed to construct URL with options: %w", err)
-				return
-			}
-			req, err := client.prepareRequest(ctx, http.MethodGet, baseURL, path, nil)
-			if err != nil {
-				iterErr = fmt.Errorf("failed to prepare pagination request: %w", err)
+			if err := ctx.Err(); err != nil {
+				iterErr = err
 				return
 			}
 
-			page := new(paginatedResponse[T])
-
-			resp, err := client.do(ctx, req, page)
+			items, resp, err := fetchPage(ctx, paginationOptions)
 			if err != nil {
 				iterErr = err
 				return
 			}
-			if l := page.Links; l != nil {
-				resp.Links = l
+			if resp == nil {
+				iterErr = errors.New("pagination response is missing")
+				return
 			}
 
-			for _, item := range page.Data {
+			for _, item := range items {
 				if !yield(item, resp) {
-					// stop iteration if the consumer stops
 					return
 				}
 			}
 
 			if resp.Links == nil || resp.Links.Next == "" {
-				// no more next pages, exit from pagination
-				break
+				return
 			}
 
 			startingAfter, err := extractStartingAfterQueryParam(resp.Links.Next)
@@ -71,7 +52,18 @@ func newPaginator[T any](ctx context.Context, client *Client, baseURL *url.URL, 
 				iterErr = fmt.Errorf("failed to extract starting_after query param: %w", err)
 				return
 			}
-			opts.StartingAfter = startingAfter
+			if startingAfter == "" {
+				iterErr = errors.New("next-page link has no starting_after cursor")
+				return
+			}
+			if _, seen := seenCursors[startingAfter]; seen {
+				iterErr = errors.New("next-page link repeats a previously seen starting_after cursor")
+				return
+			}
+
+			seenCursors[startingAfter] = struct{}{}
+			paginationOptions.StartingAfter = startingAfter
+			paginationOptions.EndingBefore = ""
 		}
 	}
 

--- a/snyk/paginator_test.go
+++ b/snyk/paginator_test.go
@@ -1,14 +1,215 @@
 package snyk
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func Test_extractStartingAfterQueryParam(t *testing.T) {
-	t.Parallel()
+func TestPaginator_newPaginator_multiplePages(t *testing.T) {
+	var gotOptions []ListOptions
+	firstResponse := &Response{Links: &PaginatedLinks{Next: "/rest/items?starting_after=next-cursor"}}
+	secondResponse := &Response{}
+	fetch := func(_ context.Context, opts ListOptions) ([]string, *Response, error) {
+		gotOptions = append(gotOptions, opts)
+		if len(gotOptions) == 1 {
+			return []string{"first", "second"}, firstResponse, nil
+		}
+		return []string{"third"}, secondResponse, nil
+	}
 
+	seq, iterErr := newPaginator(context.Background(), ListOptions{
+		EndingBefore: "initial-ending-cursor",
+		Limit:        20,
+	}, fetch)
+
+	var gotItems []string
+	var gotResponses []*Response
+	for item, response := range seq {
+		gotItems = append(gotItems, item)
+		gotResponses = append(gotResponses, response)
+	}
+
+	require.NoError(t, iterErr())
+	assert.Equal(t, []string{"first", "second", "third"}, gotItems)
+	assert.Equal(t, []*Response{firstResponse, firstResponse, secondResponse}, gotResponses)
+	assert.Equal(t, []ListOptions{
+		{EndingBefore: "initial-ending-cursor", Limit: 20},
+		{StartingAfter: "next-cursor", Limit: 20},
+	}, gotOptions)
+}
+
+func TestPaginator_newPaginator_restartsSequentialIteration(t *testing.T) {
+	var gotOptions []ListOptions
+	fetch := func(_ context.Context, opts ListOptions) ([]string, *Response, error) {
+		gotOptions = append(gotOptions, opts)
+		if opts.StartingAfter == "initial-cursor" {
+			return []string{"first"}, &Response{Links: &PaginatedLinks{Next: "/rest/items?starting_after=next-cursor"}}, nil
+		}
+		return []string{"second"}, &Response{}, nil
+	}
+
+	seq, iterErr := newPaginator(context.Background(), ListOptions{StartingAfter: "initial-cursor"}, fetch)
+
+	for range seq {
+	}
+	require.NoError(t, iterErr())
+	for range seq {
+	}
+	require.NoError(t, iterErr())
+
+	assert.Equal(t, []ListOptions{
+		{StartingAfter: "initial-cursor"},
+		{StartingAfter: "next-cursor"},
+		{StartingAfter: "initial-cursor"},
+		{StartingAfter: "next-cursor"},
+	}, gotOptions)
+}
+
+func TestPaginator_newPaginator_resetsErrorForNextSequentialIteration(t *testing.T) {
+	fetchCount := 0
+	fetchErr := errors.New("fetch page")
+	fetch := func(_ context.Context, _ ListOptions) ([]string, *Response, error) {
+		fetchCount++
+		if fetchCount == 1 {
+			return nil, nil, fetchErr
+		}
+		return []string{"recovered"}, &Response{}, nil
+	}
+
+	seq, iterErr := newPaginator(context.Background(), ListOptions{}, fetch)
+	for range seq {
+	}
+	require.ErrorIs(t, iterErr(), fetchErr)
+
+	var gotItems []string
+	for item := range seq {
+		gotItems = append(gotItems, item)
+	}
+
+	assert.Equal(t, []string{"recovered"}, gotItems)
+	require.NoError(t, iterErr())
+}
+
+func TestPaginator_newPaginator_propagatesFetchError(t *testing.T) {
+	fetchErr := errors.New("fetch page")
+	seq, iterErr := newPaginator(context.Background(), ListOptions{}, func(context.Context, ListOptions) ([]string, *Response, error) {
+		return nil, &Response{}, fetchErr
+	})
+
+	for range seq {
+		t.Fatal("unexpected item")
+	}
+
+	require.ErrorIs(t, iterErr(), fetchErr)
+}
+
+func TestPaginator_newPaginator_rejectsMissingResponse(t *testing.T) {
+	seq, iterErr := newPaginator(context.Background(), ListOptions{}, func(context.Context, ListOptions) ([]string, *Response, error) {
+		return []string{"item"}, nil, nil
+	})
+
+	for range seq {
+		t.Fatal("unexpected item")
+	}
+
+	assert.EqualError(t, iterErr(), "pagination response is missing")
+}
+
+func TestPaginator_newPaginator_rejectsInvalidNextCursor(t *testing.T) {
+	tests := []struct {
+		name           string
+		initialOptions ListOptions
+		next           string
+		wantErr        string
+	}{
+		{
+			name:    "malformed next link",
+			next:    "://invalid",
+			wantErr: "failed to extract starting_after query param: failed to parse pagination path:",
+		},
+		{
+			name:    "missing cursor",
+			next:    "/rest/items?limit=10",
+			wantErr: "next-page link has no starting_after cursor",
+		},
+		{
+			name:           "repeated current cursor",
+			initialOptions: ListOptions{StartingAfter: "current-cursor"},
+			next:           "/rest/items?starting_after=current-cursor",
+			wantErr:        "next-page link repeats a previously seen starting_after cursor",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			seq, iterErr := newPaginator(context.Background(), tt.initialOptions, func(context.Context, ListOptions) ([]string, *Response, error) {
+				return nil, &Response{Links: &PaginatedLinks{Next: tt.next}}, nil
+			})
+
+			for range seq {
+			}
+
+			assert.ErrorContains(t, iterErr(), tt.wantErr)
+		})
+	}
+}
+
+func TestPaginator_newPaginator_rejectsCursorCycle(t *testing.T) {
+	fetchCount := 0
+	fetch := func(_ context.Context, _ ListOptions) ([]string, *Response, error) {
+		fetchCount++
+		nextCursor := map[int]string{1: "cursor-a", 2: "cursor-b", 3: "cursor-a"}[fetchCount]
+		return nil, &Response{Links: &PaginatedLinks{Next: "/rest/items?starting_after=" + nextCursor}}, nil
+	}
+
+	seq, iterErr := newPaginator(context.Background(), ListOptions{}, fetch)
+	for range seq {
+	}
+
+	assert.Equal(t, 3, fetchCount)
+	assert.EqualError(t, iterErr(), "next-page link repeats a previously seen starting_after cursor")
+}
+
+func TestPaginator_newPaginator_honorsCanceledContextBeforeFetch(t *testing.T) {
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	fetchCalled := false
+	seq, iterErr := newPaginator(canceledCtx, ListOptions{}, func(context.Context, ListOptions) ([]string, *Response, error) {
+		fetchCalled = true
+		return nil, &Response{}, nil
+	})
+
+	for range seq {
+	}
+
+	assert.False(t, fetchCalled)
+	require.ErrorIs(t, iterErr(), context.Canceled)
+}
+
+func TestPaginator_newPaginator_stopsWhenConsumerStops(t *testing.T) {
+	fetchCount := 0
+	seq, iterErr := newPaginator(context.Background(), ListOptions{}, func(context.Context, ListOptions) ([]string, *Response, error) {
+		fetchCount++
+		return []string{"first", "second"}, &Response{Links: &PaginatedLinks{Next: "/rest/items?starting_after=next-cursor"}}, nil
+	})
+
+	var gotItems []string
+	for item := range seq {
+		gotItems = append(gotItems, item)
+		break
+	}
+
+	assert.Equal(t, []string{"first"}, gotItems)
+	assert.Equal(t, 1, fetchCount)
+	require.NoError(t, iterErr())
+}
+
+func TestPaginator_extractStartingAfterQueryParam(t *testing.T) {
 	tests := map[string]struct {
 		path          string
 		expectedToken string
@@ -17,23 +218,21 @@ func Test_extractStartingAfterQueryParam(t *testing.T) {
 		"success-token-extraction": {
 			path:          "/rest/orgs?limit=20&starting_after=v1.eyJuYW1&version=2024-10-15",
 			expectedToken: "v1.eyJuYW1",
-			errorExpected: false,
 		},
 		"empty-string-when-token-not-present": {
 			path:          "/rest/orgs?limit=20&version=2024-10-15",
 			expectedToken: "",
-			errorExpected: false,
 		},
 		"empty-string-when-path-without-query-params": {
 			path:          "/rest/orgs",
 			expectedToken: "",
-			errorExpected: false,
 		},
 		"error-malformed-url": {
 			path:          "://a",
 			errorExpected: true,
 		},
 	}
+
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			actualToken, err := extractStartingAfterQueryParam(test.path)
@@ -42,7 +241,7 @@ func Test_extractStartingAfterQueryParam(t *testing.T) {
 			if test.errorExpected {
 				assert.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err, fmt.Sprintf("extract cursor from %q", test.path))
 			}
 		})
 	}

--- a/snyk/paginator_test.go
+++ b/snyk/paginator_test.go
@@ -97,7 +97,9 @@ func TestPaginator_newPaginator_resetsErrorForNextSequentialIteration(t *testing
 
 func TestPaginator_newPaginator_propagatesFetchError(t *testing.T) {
 	fetchErr := errors.New("fetch page")
+	fetchCount := 0
 	seq, iterErr := newPaginator(context.Background(), ListOptions{}, func(context.Context, ListOptions) ([]string, *Response, error) {
+		fetchCount++
 		return nil, &Response{}, fetchErr
 	})
 
@@ -105,6 +107,7 @@ func TestPaginator_newPaginator_propagatesFetchError(t *testing.T) {
 		t.Fatal("unexpected item")
 	}
 
+	assert.Equal(t, 1, fetchCount)
 	require.ErrorIs(t, iterErr(), fetchErr)
 }
 
@@ -245,4 +248,12 @@ func TestPaginator_extractStartingAfterQueryParam(t *testing.T) {
 			}
 		})
 	}
+}
+
+func mustStartingAfter(t *testing.T, path string) string {
+	t.Helper()
+
+	cursor, err := extractStartingAfterQueryParam(path)
+	require.NoError(t, err)
+	return cursor
 }

--- a/snyk/projects.go
+++ b/snyk/projects.go
@@ -4,65 +4,109 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"iter"
 	"net/http"
-	"time"
+	"slices"
 )
 
 const (
-	projectsBaseBase   = orgsBasePath + "/%v/projects"
+	projectsBasePath   = orgsBasePath + "/%v/projects"
 	projectsAPIVersion = "2025-11-05"
 )
 
-// ProjectsService handles communication with the projects related methods of the Snyk API.
+// ProjectsService handles communication with the Projects REST API.
 type ProjectsService service
 
-// Project represents a Snyk project.
+// ProjectType identifies the server-reported ecosystem or analysis type of Project.
+// Unknown values remain valid so the SDK can represent new Project types introduced by Snyk.
+type ProjectType string
+
+// ProjectOrigin identifies how or through which integration a Project was created.
+// Unknown values remain valid so the SDK can represent new origins introduced by Snyk.
+type ProjectOrigin string
+
+// ProjectMonitoringStatus identifies whether Snyk is actively monitoring a Project.
+// Unknown values remain valid so the SDK can represent new statuses introduced by Snyk.
+type ProjectMonitoringStatus string
+
+const (
+	// ProjectMonitoringStatusActive identifies a Project that Snyk actively monitors.
+	ProjectMonitoringStatusActive ProjectMonitoringStatus = "active"
+	// ProjectMonitoringStatusInactive identifies a Project that Snyk does not actively monitor.
+	ProjectMonitoringStatusInactive ProjectMonitoringStatus = "inactive"
+)
+
+// Project represents a Snyk Project.
 //
-// See: https://docs.snyk.io/discover-snyk/getting-started/glossary#project
+// Its JSON representation is SDK-owned and distinct from the Snyk REST
+// JSON:API representation. Existing JSON field names are part of the public
+// SDK contract. Project is a read model and is not a REST request payload.
 type Project struct {
-	ID         string             `json:"id"`                   // The Project identifier.
-	Type       string             `json:"type"`                 // The resource type `project`.
-	Attributes *ProjectAttributes `json:"attributes,omitempty"` // The Project resource data.
+	ID               string                  `json:"id"`                // The Project identifier.
+	Name             string                  `json:"name"`              // The Project display name.
+	ProjectType      ProjectType             `json:"project_type"`      // The ecosystem or analysis type.
+	Origin           ProjectOrigin           `json:"origin"`            // How or through which integration the Project was created.
+	MonitoringStatus ProjectMonitoringStatus `json:"monitoring_status"` // Whether Snyk actively monitors the Project.
+
+	// TargetPath identifies the Project's location within its target, such as a
+	// manifest file or a directory within a scanned image. It is empty when Snyk
+	// does not report a narrower location within the target.
+	TargetPath string `json:"target_path"`
+
+	// TargetReference contains target-specific information used to resolve the
+	// revision or variant that was scanned. For example, it may be a source-control
+	// branch or another origin-specific reference.
+	TargetReference string `json:"target_reference"`
 }
 
-type ProjectAttributes struct {
-	CreatedAt       time.Time `json:"created,omitempty"`          // The date that the Project was created at.
-	Name            string    `json:"name,omitempty"`             // The name of the Project.
-	Origin          string    `json:"origin,omitempty"`           // The origin the Project was added from, e.g. 'github'.
-	Status          string    `json:"status,omitempty"`           // The status of the Project describes if the project is monitored or de-activated.
-	TargetFile      string    `json:"target_file,omitempty"`      // Path within the target to identify a specific file/directory/image etc.
-	TargetReference string    `json:"target_reference,omitempty"` // The additional information required to resolve which revision of the resource should be scanned.
-	Type            string    `json:"type,omitempty"`             // The ID of the organization containing the AppInstall.
-}
+// String returns a string representation of the Project.
+func (p Project) String() string { return Stringify(p) }
 
-type ListProjectsOptions struct {
+// ProjectListOptions specifies filters and pagination for List.
+type ProjectListOptions struct {
 	ListOptions
+	IDs             []string        `url:"ids,comma,omitempty"`              // Return Projects matching these IDs.
+	Names           []string        `url:"names,comma,omitempty"`            // Return Projects matching these names.
+	NamePrefixes    []string        `url:"names_start_with,comma,omitempty"` // Return Projects whose names start with these prefixes.
+	ProjectTypes    []ProjectType   `url:"types,comma,omitempty"`            // Return Projects matching these Project types.
+	Origins         []ProjectOrigin `url:"origins,comma,omitempty"`          // Return Projects matching these origins.
+	TargetPath      string          `url:"target_file,omitempty"`            // Return Projects matching this location within their target.
+	TargetReference string          `url:"target_reference,omitempty"`       // Return Projects matching this target reference.
+}
+
+type projectAttributes struct {
+	Name            string `json:"name"`
+	Type            string `json:"type"`
+	Origin          string `json:"origin"`
+	Status          string `json:"status"`
+	TargetFile      string `json:"target_file"`
+	TargetReference string `json:"target_reference"`
+}
+
+type projectResource struct {
+	ID         string             `json:"id"`
+	Type       string             `json:"type"`
+	Attributes *projectAttributes `json:"attributes"`
 }
 
 type projectRoot struct {
-	Project *Project `json:"data"`
+	Project *projectResource `json:"data"`
 }
 
 type projectsRoot struct {
-	Projects []Project       `json:"data"`
-	Links    *PaginatedLinks `json:"links,omitempty"`
+	Projects []projectResource `json:"data"`
+	Links    *PaginatedLinks   `json:"links,omitempty"`
 }
 
-func (p Project) String() string { return Stringify(p) }
-
-// List provides a list of all projects for the organization.
+// List provides one page of Projects for an organization.
 //
 // See: https://docs.snyk.io/snyk-api/reference/projects#get-orgs-org_id-projects
-func (s *ProjectsService) List(ctx context.Context, orgID string, opts *ListProjectsOptions) ([]Project, *Response, error) {
+func (s *ProjectsService) List(ctx context.Context, orgID string, opts *ProjectListOptions) ([]Project, *Response, error) {
 	if orgID == "" {
-		return nil, nil, errors.New("orgID must be supplied")
+		return nil, nil, fmt.Errorf("organization ID: %w", ErrEmptyArgument)
 	}
 
-	if opts == nil {
-		opts = &ListProjectsOptions{ListOptions: ListOptions{Limit: 100}}
-	}
-
-	path, err := restPath(fmt.Sprintf(projectsBaseBase, orgID), projectsAPIVersion, opts)
+	path, err := restPath(fmt.Sprintf(projectsBasePath, orgID), projectsAPIVersion, opts)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -73,29 +117,69 @@ func (s *ProjectsService) List(ctx context.Context, orgID string, opts *ListProj
 	}
 
 	root := new(projectsRoot)
-	resp, err := s.client.do(ctx, req, &root)
+	resp, err := s.client.do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
-	if l := root.Links; l != nil {
-		resp.Links = l
+	if root.Links != nil {
+		resp.Links = root.Links
+	}
+	if root.Projects == nil {
+		return nil, resp, errors.New("convert projects: response data is missing")
 	}
 
-	return root.Projects, resp, nil
+	projects, err := projectsFromResources(root.Projects)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return projects, resp, nil
 }
 
-// Get provides the full details about the project.
+// All returns an iterator over Projects for an organization.
+//
+// Pagination starts from opts.StartingAfter when supplied, so the iterator returns all
+// remaining Projects after that cursor rather than restarting from the first page.
+// Each page is converted atomically: if a page is malformed, none of its Projects are
+// yielded, while Projects from earlier pages remain yielded.
+//
+// The returned sequence may be iterated multiple times sequentially. It is not safe
+// for concurrent or overlapping iteration.
+//
+// This method is experimental and its signature may change in a future release.
+//
+// See: https://docs.snyk.io/snyk-api/reference/projects#get-orgs-org_id-projects
+func (s *ProjectsService) All(ctx context.Context, orgID string, opts *ProjectListOptions) (iter.Seq2[Project, *Response], func() error) {
+	if orgID == "" {
+		validationErr := fmt.Errorf("organization ID: %w", ErrEmptyArgument)
+		return func(func(Project, *Response) bool) {}, func() error { return validationErr }
+	}
+
+	baseOptions := cloneProjectListOptions(opts)
+	if baseOptions.EndingBefore != "" {
+		validationErr := errors.New("ending-before pagination is not supported when iterating all projects")
+		return func(func(Project, *Response) bool) {}, func() error { return validationErr }
+	}
+
+	return newPaginator(ctx, baseOptions.ListOptions, func(ctx context.Context, pageOptions ListOptions) ([]Project, *Response, error) {
+		currentOptions := baseOptions
+		currentOptions.ListOptions = pageOptions
+		return s.List(ctx, orgID, &currentOptions)
+	})
+}
+
+// Get provides one Project by organization and Project ID.
 //
 // See: https://docs.snyk.io/snyk-api/reference/projects#get-orgs-org_id-projects-project_id
 func (s *ProjectsService) Get(ctx context.Context, orgID, projectID string) (*Project, *Response, error) {
 	if orgID == "" {
-		return nil, nil, errors.New("orgID must be supplied")
+		return nil, nil, fmt.Errorf("organization ID: %w", ErrEmptyArgument)
 	}
 	if projectID == "" {
-		return nil, nil, errors.New("projectID must be supplied")
+		return nil, nil, fmt.Errorf("project ID: %w", ErrEmptyArgument)
 	}
 
-	path, err := restPath(fmt.Sprintf(projectsBaseBase+"/%v", orgID, projectID), projectsAPIVersion, nil)
+	path, err := restPath(fmt.Sprintf(projectsBasePath+"/%v", orgID, projectID), projectsAPIVersion, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -106,10 +190,91 @@ func (s *ProjectsService) Get(ctx context.Context, orgID, projectID string) (*Pr
 	}
 
 	root := new(projectRoot)
-	resp, err := s.client.do(ctx, req, &root)
+	resp, err := s.client.do(ctx, req, root)
 	if err != nil {
 		return nil, resp, err
 	}
+	if root.Project == nil {
+		return nil, resp, errors.New("convert project: response data is missing")
+	}
 
-	return root.Project, resp, nil
+	project, err := projectFromResource(*root.Project)
+	if err != nil {
+		return nil, resp, fmt.Errorf("convert project: %w", err)
+	}
+
+	return &project, resp, nil
+}
+
+// Delete deletes one Project.
+//
+// See: https://docs.snyk.io/snyk-api/reference/projects#delete-orgs-org_id-projects-project_id
+func (s *ProjectsService) Delete(ctx context.Context, orgID, projectID string) (*Response, error) {
+	if orgID == "" {
+		return nil, fmt.Errorf("organization ID: %w", ErrEmptyArgument)
+	}
+	if projectID == "" {
+		return nil, fmt.Errorf("project ID: %w", ErrEmptyArgument)
+	}
+
+	path, err := restPath(fmt.Sprintf(projectsBasePath+"/%v", orgID, projectID), projectsAPIVersion, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.prepareRequest(ctx, http.MethodDelete, s.client.restBaseURL, path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.client.do(ctx, req, nil)
+}
+
+func projectFromResource(resource projectResource) (Project, error) {
+	if resource.ID == "" {
+		return Project{}, errors.New("resource ID is empty")
+	}
+	if resource.Type != "project" {
+		return Project{}, fmt.Errorf("project %q: resource type is %q, expected %q", resource.ID, resource.Type, "project")
+	}
+	if resource.Attributes == nil {
+		return Project{}, fmt.Errorf("project %q: attributes are missing", resource.ID)
+	}
+
+	return Project{
+		ID:               resource.ID,
+		Name:             resource.Attributes.Name,
+		ProjectType:      ProjectType(resource.Attributes.Type),
+		Origin:           ProjectOrigin(resource.Attributes.Origin),
+		MonitoringStatus: ProjectMonitoringStatus(resource.Attributes.Status),
+		TargetPath:       resource.Attributes.TargetFile,
+		TargetReference:  resource.Attributes.TargetReference,
+	}, nil
+}
+
+func projectsFromResources(resources []projectResource) ([]Project, error) {
+	projects := make([]Project, 0, len(resources))
+	for i, resource := range resources {
+		project, err := projectFromResource(resource)
+		if err != nil {
+			return nil, fmt.Errorf("convert project at index %d: %w", i, err)
+		}
+		projects = append(projects, project)
+	}
+
+	return projects, nil
+}
+
+func cloneProjectListOptions(opts *ProjectListOptions) ProjectListOptions {
+	if opts == nil {
+		return ProjectListOptions{}
+	}
+
+	cloned := *opts
+	cloned.IDs = slices.Clone(opts.IDs)
+	cloned.Names = slices.Clone(opts.Names)
+	cloned.NamePrefixes = slices.Clone(opts.NamePrefixes)
+	cloned.ProjectTypes = slices.Clone(opts.ProjectTypes)
+	cloned.Origins = slices.Clone(opts.Origins)
+	return cloned
 }

--- a/snyk/projects_test.go
+++ b/snyk/projects_test.go
@@ -35,7 +35,7 @@ func TestProject_MarshalJSON(t *testing.T) {
 	}`, string(got))
 }
 
-func TestProjectFromResource(t *testing.T) {
+func TestProjects_projectFromResource(t *testing.T) {
 	resource := projectResource{
 		ID:   "project-id",
 		Type: "project",
@@ -55,15 +55,15 @@ func TestProjectFromResource(t *testing.T) {
 	assert.Equal(t, Project{
 		ID:               "project-id",
 		Name:             "example",
-		ProjectType:      ProjectType("future-project-type"),
-		Origin:           ProjectOrigin("future-origin"),
-		MonitoringStatus: ProjectMonitoringStatus("future-status"),
+		ProjectType:      "future-project-type",
+		Origin:           "future-origin",
+		MonitoringStatus: "future-status",
 		TargetPath:       "path/to/project",
 		TargetReference:  "future-reference",
 	}, project)
 }
 
-func TestProjectFromResource_rejectsStructuralViolations(t *testing.T) {
+func TestProjects_projectFromResource_rejectsStructuralViolations(t *testing.T) {
 	tests := []struct {
 		name     string
 		resource projectResource
@@ -96,7 +96,7 @@ func TestProjectFromResource_rejectsStructuralViolations(t *testing.T) {
 }
 
 func TestProjects_List_success(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	fixture := loadFixture(t, "projects_list_success.json")
@@ -136,8 +136,8 @@ func TestProjects_List_success(t *testing.T) {
 	assert.Equal(t, Project{
 		ID:               "11111111-1111-1111-1111-111111111111",
 		Name:             "fake-image:/usr/local/lib/node_modules",
-		ProjectType:      ProjectType("npm"),
-		Origin:           ProjectOrigin("cli"),
+		ProjectType:      "npm",
+		Origin:           "cli",
 		MonitoringStatus: ProjectMonitoringStatusActive,
 		TargetPath:       "/usr/local/lib/node_modules",
 		TargetReference:  "docker-image|fake-image",
@@ -145,17 +145,18 @@ func TestProjects_List_success(t *testing.T) {
 	assert.Equal(t, Project{
 		ID:               "22222222-2222-2222-2222-222222222222",
 		Name:             "fake-org/fake-repository",
-		ProjectType:      ProjectType("sast"),
-		Origin:           ProjectOrigin("github-cloud-app"),
+		ProjectType:      "sast",
+		Origin:           "github-cloud-app",
 		MonitoringStatus: ProjectMonitoringStatusInactive,
 		TargetPath:       "",
 		TargetReference:  "main",
 	}, projects[1])
+	require.NotNil(t, response.Links)
 	assert.Equal(t, "next-cursor", mustStartingAfter(t, response.Links.Next))
 }
 
 func TestProjects_List_nilOptions(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/orgs/org-id/projects", func(w http.ResponseWriter, r *http.Request) {
@@ -171,7 +172,7 @@ func TestProjects_List_nilOptions(t *testing.T) {
 }
 
 func TestProjects_List_rejectsMalformedResourceWithContext(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/orgs/org-id/projects", func(w http.ResponseWriter, _ *http.Request) {
@@ -201,7 +202,7 @@ func TestProjects_List_rejectsMissingOrNullData(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			setup()
+			setup(t)
 			defer teardown()
 
 			mux.HandleFunc("/orgs/org-id/projects", func(w http.ResponseWriter, _ *http.Request) {
@@ -217,17 +218,8 @@ func TestProjects_List_rejectsMissingOrNullData(t *testing.T) {
 	}
 }
 
-func TestProjects_List_validatesOrgID(t *testing.T) {
-	projects, response, err := client.Projects.List(ctx, "", nil)
-
-	assert.Nil(t, projects)
-	assert.Nil(t, response)
-	require.ErrorIs(t, err, ErrEmptyArgument)
-	require.EqualError(t, err, "organization ID: argument is empty")
-}
-
 func TestProjects_All_multiplePages(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	page1 := loadFixture(t, "projects_all_page_1.json")
@@ -293,27 +285,31 @@ func TestProjects_All_multiplePages(t *testing.T) {
 }
 
 func TestProjects_All_snapshotsOptionsAtConstruction(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	options := &ProjectListOptions{
-		ListOptions:  ListOptions{StartingAfter: "original-cursor", Limit: 10},
-		IDs:          []string{"original-id"},
-		Names:        []string{"original-name"},
-		NamePrefixes: []string{"original-prefix"},
-		ProjectTypes: []ProjectType{"original-type"},
-		Origins:      []ProjectOrigin{"original-origin"},
+		ListOptions:     ListOptions{StartingAfter: "original-cursor", Limit: 10},
+		IDs:             []string{"original-id"},
+		Names:           []string{"original-name"},
+		NamePrefixes:    []string{"original-prefix"},
+		ProjectTypes:    []ProjectType{"original-type"},
+		Origins:         []ProjectOrigin{"original-origin"},
+		TargetPath:      "original-path",
+		TargetReference: "original-reference",
 	}
 	seq, iterErr := client.Projects.All(ctx, "org-id", options)
 
 	options.StartingAfter = "changed-cursor"
 	options.EndingBefore = "changed-ending-cursor"
 	options.Limit = 99
-	options.IDs = []string{"replacement-id"}
+	options.IDs[0] = "mutated-id"
 	options.Names[0] = "mutated-name"
 	options.NamePrefixes[0] = "mutated-prefix"
 	options.ProjectTypes[0] = "mutated-type"
 	options.Origins[0] = "mutated-origin"
+	options.TargetPath = "mutated-path"
+	options.TargetReference = "mutated-reference"
 
 	requestCount := 0
 	mux.HandleFunc("/orgs/org-id/projects", func(w http.ResponseWriter, r *http.Request) {
@@ -325,6 +321,8 @@ func TestProjects_All_snapshotsOptionsAtConstruction(t *testing.T) {
 			"names_start_with": {"original-prefix"},
 			"origins":          {"original-origin"},
 			"starting_after":   {"original-cursor"},
+			"target_file":      {"original-path"},
+			"target_reference": {"original-reference"},
 			"types":            {"original-type"},
 			"version":          {projectsAPIVersion},
 		}, r.URL.Query())
@@ -339,7 +337,7 @@ func TestProjects_All_snapshotsOptionsAtConstruction(t *testing.T) {
 }
 
 func TestProjects_All_restartsSequentialIterationFromInitialCursor(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	page1 := loadFixture(t, "projects_all_page_1.json")
@@ -383,7 +381,7 @@ func TestProjects_All_restartsSequentialIterationFromInitialCursor(t *testing.T)
 }
 
 func TestProjects_All_rejectsEndingBefore(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	seq, iterErr := client.Projects.All(ctx, "org-id", &ProjectListOptions{
@@ -397,7 +395,7 @@ func TestProjects_All_rejectsEndingBefore(t *testing.T) {
 }
 
 func TestProjects_All_convertsEachPageAtomically(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	requestCount := 0
@@ -445,7 +443,7 @@ func TestProjects_All_rejectsMissingOrNullData(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			setup()
+			setup(t)
 			defer teardown()
 
 			mux.HandleFunc("/orgs/org-id/projects", func(w http.ResponseWriter, _ *http.Request) {
@@ -462,47 +460,13 @@ func TestProjects_All_rejectsMissingOrNullData(t *testing.T) {
 	}
 }
 
-func TestProjects_All_propagatesRESTErrorResponse(t *testing.T) {
-	setup()
-	defer teardown()
-
-	mux.HandleFunc("/orgs/org-id/projects", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set(headerSnykVersionServed, "2025-11-05")
-		w.WriteHeader(http.StatusServiceUnavailable)
-		_, _ = fmt.Fprint(w, `{"errors":[{"status":"503","title":"Temporarily unavailable"}]}`)
-	})
-
-	seq, iterErr := client.Projects.All(ctx, "org-id", nil)
-	for range seq {
-		t.Fatal("unexpected Project")
-	}
-
-	err := iterErr()
-	require.Error(t, err)
-	var errorResponse *ErrorResponse
-	require.ErrorAs(t, err, &errorResponse)
-	require.NotNil(t, errorResponse.Response)
-	assert.Equal(t, http.StatusServiceUnavailable, errorResponse.Response.StatusCode)
-	assert.Equal(t, "2025-11-05", errorResponse.Response.ServedAPIVersion)
-}
-
-func TestProjects_All_validatesOrgID(t *testing.T) {
-	seq, iterErr := client.Projects.All(ctx, "", nil)
-	for range seq {
-		t.Fatal("unexpected Project")
-	}
-
-	err := iterErr()
-	require.ErrorIs(t, err, ErrEmptyArgument)
-	require.EqualError(t, err, "organization ID: argument is empty")
-}
-
 func TestProjects_Get_success(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
+	const projectID = "11111111-1111-1111-1111-111111111111"
 	fixture := loadFixture(t, "projects_get_success.json")
-	mux.HandleFunc("/orgs/org-id/projects/project-id", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/orgs/org-id/projects/"+projectID, func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, http.MethodGet, r.Method)
 		assert.Equal(t, restAPIMediaType, r.Header.Get("Accept"))
 		assertRequestAPIVersion(t, r, projectsAPIVersion)
@@ -510,61 +474,71 @@ func TestProjects_Get_success(t *testing.T) {
 		_, _ = w.Write(fixture)
 	})
 
-	project, response, err := client.Projects.Get(ctx, "org-id", "project-id")
+	project, response, err := client.Projects.Get(ctx, "org-id", projectID)
 
 	require.NoError(t, err)
 	require.NotNil(t, response)
 	assert.Equal(t, &Project{
-		ID:               "11111111-1111-1111-1111-111111111111",
+		ID:               projectID,
 		Name:             "fake-org/fake-repository:catalog-info.yaml",
-		ProjectType:      ProjectType("k8sconfig"),
-		Origin:           ProjectOrigin("github-cloud-app"),
+		ProjectType:      "k8sconfig",
+		Origin:           "github-cloud-app",
 		MonitoringStatus: ProjectMonitoringStatusActive,
 		TargetPath:       "catalog-info.yaml",
 		TargetReference:  "main",
 	}, project)
 }
 
-func TestProjects_Get_validatesIDs(t *testing.T) {
-	project, response, err := client.Projects.Get(ctx, "", "project-id")
-	assert.Nil(t, project)
-	assert.Nil(t, response)
-	require.ErrorIs(t, err, ErrEmptyArgument)
-	require.EqualError(t, err, "organization ID: argument is empty")
+func TestProjects_Get_rejectsMissingOrNullData(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "missing data", body: `{}`},
+		{name: "null data", body: `{"data": null}`},
+	}
 
-	project, response, err = client.Projects.Get(ctx, "org-id", "")
-	assert.Nil(t, project)
-	assert.Nil(t, response)
-	require.ErrorIs(t, err, ErrEmptyArgument)
-	require.EqualError(t, err, "project ID: argument is empty")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setup(t)
+			defer teardown()
+
+			mux.HandleFunc("/orgs/org-id/projects/project-id", func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = fmt.Fprint(w, tt.body)
+			})
+
+			project, response, err := client.Projects.Get(ctx, "org-id", "project-id")
+
+			assert.Nil(t, project)
+			require.NotNil(t, response)
+			assert.EqualError(t, err, "convert project: response data is missing")
+		})
+	}
 }
 
-func TestProjects_Get_propagatesRESTErrorResponse(t *testing.T) {
-	setup()
+func TestProjects_Get_rejectsMalformedResourceWithContext(t *testing.T) {
+	setup(t)
 	defer teardown()
 
-	mux.HandleFunc("/orgs/org-id/projects/missing", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set(headerSnykVersionServed, "2024-05-31")
-		w.WriteHeader(http.StatusNotFound)
-		_, _ = fmt.Fprint(w, `{"errors":[{"status":"404","title":"Project not found"}]}`)
+	mux.HandleFunc("/orgs/org-id/projects/project-id", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, `{
+			"data": {
+				"id": "project-id",
+				"type": "target",
+				"attributes": {}
+			}
+		}`)
 	})
 
-	project, response, err := client.Projects.Get(ctx, "org-id", "missing")
+	project, response, err := client.Projects.Get(ctx, "org-id", "project-id")
 
 	assert.Nil(t, project)
-	require.Error(t, err)
-	require.NotErrorIs(t, err, ErrEmptyArgument)
 	require.NotNil(t, response)
-	assert.Equal(t, http.StatusNotFound, response.StatusCode)
-	assert.Equal(t, "2024-05-31", response.ServedAPIVersion)
-	var errorResponse *ErrorResponse
-	require.ErrorAs(t, err, &errorResponse)
-	assert.Same(t, response, errorResponse.Response)
-	assert.Equal(t, "Project not found", errorResponse.APIErrors[0].Title)
+	assert.EqualError(t, err, `convert project: project "project-id": resource type is "target", expected "project"`)
 }
 
 func TestProjects_Delete_success(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/orgs/org-id/projects/project-id", func(w http.ResponseWriter, r *http.Request) {
@@ -583,44 +557,80 @@ func TestProjects_Delete_success(t *testing.T) {
 	assert.Equal(t, http.StatusNoContent, response.StatusCode)
 }
 
-func TestProjects_Delete_validatesIDs(t *testing.T) {
-	response, err := client.Projects.Delete(ctx, "", "project-id")
-	assert.Nil(t, response)
-	require.ErrorIs(t, err, ErrEmptyArgument)
-	require.EqualError(t, err, "organization ID: argument is empty")
+func TestProjects_Validation(t *testing.T) {
+	c := newTestClient(t)
 
-	response, err = client.Projects.Delete(ctx, "org-id", "")
-	assert.Nil(t, response)
-	require.ErrorIs(t, err, ErrEmptyArgument)
-	require.EqualError(t, err, "project ID: argument is empty")
-}
+	tests := map[string]struct {
+		call    func(t *testing.T) error
+		target  error
+		message string
+	}{
+		"List/missing organization ID": {
+			call: func(t *testing.T) error {
+				projects, response, err := c.Projects.List(ctx, "", nil)
+				assert.Nil(t, projects)
+				assert.Nil(t, response)
+				return err
+			},
+			target:  ErrEmptyArgument,
+			message: "organization ID: argument is empty",
+		},
+		"All/missing organization ID": {
+			call: func(t *testing.T) error {
+				seq, iterErr := c.Projects.All(ctx, "", nil)
+				for range seq {
+					t.Fatal("unexpected Project")
+				}
+				return iterErr()
+			},
+			target:  ErrEmptyArgument,
+			message: "organization ID: argument is empty",
+		},
+		"Get/missing organization ID": {
+			call: func(t *testing.T) error {
+				project, response, err := c.Projects.Get(ctx, "", "project-id")
+				assert.Nil(t, project)
+				assert.Nil(t, response)
+				return err
+			},
+			target:  ErrEmptyArgument,
+			message: "organization ID: argument is empty",
+		},
+		"Get/missing project ID": {
+			call: func(t *testing.T) error {
+				project, response, err := c.Projects.Get(ctx, "org-id", "")
+				assert.Nil(t, project)
+				assert.Nil(t, response)
+				return err
+			},
+			target:  ErrEmptyArgument,
+			message: "project ID: argument is empty",
+		},
+		"Delete/missing organization ID": {
+			call: func(t *testing.T) error {
+				response, err := c.Projects.Delete(ctx, "", "project-id")
+				assert.Nil(t, response)
+				return err
+			},
+			target:  ErrEmptyArgument,
+			message: "organization ID: argument is empty",
+		},
+		"Delete/missing project ID": {
+			call: func(t *testing.T) error {
+				response, err := c.Projects.Delete(ctx, "org-id", "")
+				assert.Nil(t, response)
+				return err
+			},
+			target:  ErrEmptyArgument,
+			message: "project ID: argument is empty",
+		},
+	}
 
-func TestProjects_Delete_propagatesRESTErrorResponse(t *testing.T) {
-	setup()
-	defer teardown()
-
-	mux.HandleFunc("/orgs/org-id/projects/project-id", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set(headerSnykVersionServed, "2024-05-31")
-		w.WriteHeader(http.StatusForbidden)
-		_, _ = fmt.Fprint(w, `{"errors":[{"status":"403","title":"Insufficient permissions"}]}`)
-	})
-
-	response, err := client.Projects.Delete(ctx, "org-id", "project-id")
-
-	require.Error(t, err)
-	require.NotErrorIs(t, err, ErrEmptyArgument)
-	require.NotNil(t, response)
-	assert.Equal(t, http.StatusForbidden, response.StatusCode)
-	assert.Equal(t, "2024-05-31", response.ServedAPIVersion)
-	var errorResponse *ErrorResponse
-	require.ErrorAs(t, err, &errorResponse)
-	assert.Same(t, response, errorResponse.Response)
-}
-
-func mustStartingAfter(t *testing.T, path string) string {
-	t.Helper()
-
-	cursor, err := extractStartingAfterQueryParam(path)
-	require.NoError(t, err)
-	return cursor
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := test.call(t)
+			require.ErrorIs(t, err, test.target)
+			require.EqualError(t, err, test.message)
+		})
+	}
 }

--- a/snyk/projects_test.go
+++ b/snyk/projects_test.go
@@ -1,178 +1,626 @@
 package snyk
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestProject_List(t *testing.T) {
+func TestProject_MarshalJSON(t *testing.T) {
+	project := Project{
+		ID:               "project-id",
+		Name:             "example",
+		ProjectType:      ProjectType("npm"),
+		Origin:           ProjectOrigin("cli"),
+		MonitoringStatus: ProjectMonitoringStatusActive,
+		TargetPath:       "",
+		TargetReference:  "",
+	}
+
+	got, err := json.Marshal(project)
+	require.NoError(t, err)
+	require.JSONEq(t, `{
+		"id": "project-id",
+		"name": "example",
+		"project_type": "npm",
+		"origin": "cli",
+		"monitoring_status": "active",
+		"target_path": "",
+		"target_reference": ""
+	}`, string(got))
+}
+
+func TestProjectFromResource(t *testing.T) {
+	resource := projectResource{
+		ID:   "project-id",
+		Type: "project",
+		Attributes: &projectAttributes{
+			Name:            "example",
+			Type:            "future-project-type",
+			Origin:          "future-origin",
+			Status:          "future-status",
+			TargetFile:      "path/to/project",
+			TargetReference: "future-reference",
+		},
+	}
+
+	project, err := projectFromResource(resource)
+
+	require.NoError(t, err)
+	assert.Equal(t, Project{
+		ID:               "project-id",
+		Name:             "example",
+		ProjectType:      ProjectType("future-project-type"),
+		Origin:           ProjectOrigin("future-origin"),
+		MonitoringStatus: ProjectMonitoringStatus("future-status"),
+		TargetPath:       "path/to/project",
+		TargetReference:  "future-reference",
+	}, project)
+}
+
+func TestProjectFromResource_rejectsStructuralViolations(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource projectResource
+		wantErr  string
+	}{
+		{
+			name:     "empty resource ID",
+			resource: projectResource{Type: "project", Attributes: &projectAttributes{}},
+			wantErr:  "resource ID is empty",
+		},
+		{
+			name:     "wrong resource type",
+			resource: projectResource{ID: "project-id", Type: "target", Attributes: &projectAttributes{}},
+			wantErr:  `project "project-id": resource type is "target", expected "project"`,
+		},
+		{
+			name:     "missing attributes",
+			resource: projectResource{ID: "project-id", Type: "project"},
+			wantErr:  `project "project-id": attributes are missing`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := projectFromResource(tt.resource)
+
+			assert.EqualError(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestProjects_List_success(t *testing.T) {
+	setup()
+	defer teardown()
+
+	fixture := loadFixture(t, "projects_list_success.json")
+	mux.HandleFunc("/orgs/org-id/projects", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, restAPIMediaType, r.Header.Get("Accept"))
+		assertRequestAPIVersion(t, r, projectsAPIVersion)
+		assert.Equal(t, url.Values{
+			"ending_before":    {"ending-cursor"},
+			"ids":              {"project-a,project-b"},
+			"limit":            {"20"},
+			"names":            {"project-a,project-b"},
+			"names_start_with": {"service-,library-"},
+			"origins":          {"github-cloud-app,cli"},
+			"target_file":      {"package.json"},
+			"target_reference": {"main"},
+			"types":            {"npm,sast"},
+			"version":          {projectsAPIVersion},
+		}, r.URL.Query())
+		_, _ = w.Write(fixture)
+	})
+
+	projects, response, err := client.Projects.List(ctx, "org-id", &ProjectListOptions{
+		ListOptions:     ListOptions{EndingBefore: "ending-cursor", Limit: 20},
+		IDs:             []string{"project-a", "project-b"},
+		Names:           []string{"project-a", "project-b"},
+		NamePrefixes:    []string{"service-", "library-"},
+		ProjectTypes:    []ProjectType{"npm", "sast"},
+		Origins:         []ProjectOrigin{"github-cloud-app", "cli"},
+		TargetPath:      "package.json",
+		TargetReference: "main",
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, response)
+	require.Len(t, projects, 2)
+	assert.Equal(t, Project{
+		ID:               "11111111-1111-1111-1111-111111111111",
+		Name:             "fake-image:/usr/local/lib/node_modules",
+		ProjectType:      ProjectType("npm"),
+		Origin:           ProjectOrigin("cli"),
+		MonitoringStatus: ProjectMonitoringStatusActive,
+		TargetPath:       "/usr/local/lib/node_modules",
+		TargetReference:  "docker-image|fake-image",
+	}, projects[0])
+	assert.Equal(t, Project{
+		ID:               "22222222-2222-2222-2222-222222222222",
+		Name:             "fake-org/fake-repository",
+		ProjectType:      ProjectType("sast"),
+		Origin:           ProjectOrigin("github-cloud-app"),
+		MonitoringStatus: ProjectMonitoringStatusInactive,
+		TargetPath:       "",
+		TargetReference:  "main",
+	}, projects[1])
+	assert.Equal(t, "next-cursor", mustStartingAfter(t, response.Links.Next))
+}
+
+func TestProjects_List_nilOptions(t *testing.T) {
 	setup()
 	defer teardown()
 
 	mux.HandleFunc("/orgs/org-id/projects", func(w http.ResponseWriter, r *http.Request) {
-		assertRequestAPIVersion(t, r, projectsAPIVersion)
-		_, _ = fmt.Fprint(w, `
-{
-  "jsonapi": { "version": "1.0" },
-  "data": [
-    {
-      "type": "project",
-      "id": "7f76f013-a3fd-4151-95e2-b3a347dc8546",
-      "meta": {},
-      "attributes": {
-        "name": "test-user/test-project-1:package.json",
-        "type": "npm",
-        "target_file": "package.json",
-        "target_reference": "main",
-        "origin": "gitlab",
-        "created": "2012-12-12T12:12:12.127Z",
-        "status": "active",
-        "business_criticality": [ "medium", "low" ],
-        "environment": [ "external" ],
-        "lifecycle": [ "development" ],
-        "tags": [],
-        "read_only": false,
-        "settings": { "recurring_tests": { "frequency": "weekly" }, "pull_requests": {} }
-      },
-      "relationships": {
-        "organization": {
-          "data": { "type": "org", "id": "2bd5babe-884b-49c5-9e82-0ce9f2a3a147" },
-          "links": {}
-        },
-        "target": {
-          "data": { "type": "target", "id": "ccd00feb-45c1-4e03-80c3-8eba50fac80a" },
-          "links": { "related": "/rest/orgs/2bd5babe-884b-49c5-9e82-0ce9f2a3a147/targets/ccd00feb-45c1-4e03-80c3-8eba50fac80a" }
-        },
-        "owner": {
-          "data": { "type": "user", "id": "f210d0ed-61b2-4588-a997-56346f61a7a7" },
-          "links": { "related": "/rest/orgs/2bd5babe-884b-49c5-9e82-0ce9f2a3a147/users/f210d0ed-61b2-4588-a997-56346f61a7a7" }
-        },
-        "importer": {
-          "data": { "type": "user", "id": "f210d0ed-61b2-4588-a997-56346f61a7a7" },
-          "links": { "related": "/rest/orgs/2bd5babe-884b-49c5-9e82-0ce9f2a3a147/users/f210d0ed-61b2-4588-a997-56346f61a7a7" }
-        }
-      }
-    }
-  ],
-  "links": {}
-}
-`)
+		assert.Equal(t, url.Values{"version": {projectsAPIVersion}}, r.URL.Query())
+		_, _ = fmt.Fprint(w, `{"data":[],"links":{}}`)
 	})
-	createdAtTime, _ := time.Parse(time.RFC3339, "2012-12-12T12:12:12.127Z")
-	expectedProjects := []Project{{
-		ID:   "7f76f013-a3fd-4151-95e2-b3a347dc8546",
-		Type: "project",
-		Attributes: &ProjectAttributes{
-			CreatedAt:       createdAtTime,
-			Name:            "test-user/test-project-1:package.json",
-			Origin:          "gitlab",
-			Status:          "active",
-			TargetFile:      "package.json",
-			TargetReference: "main",
-			Type:            "npm",
-		},
-	}}
 
-	actualProjects, _, err := client.Projects.List(ctx, "org-id", nil)
+	projects, _, err := client.Projects.List(ctx, "org-id", nil)
 
-	assert.NoError(t, err)
-	assert.Equal(t, 1, len(actualProjects))
-	assert.Equal(t, expectedProjects, actualProjects)
+	require.NoError(t, err)
+	assert.NotNil(t, projects)
+	assert.Empty(t, projects)
 }
 
-func TestProject_List_emptyOrgID(t *testing.T) {
-	_, _, err := client.Projects.List(ctx, "", nil)
+func TestProjects_List_rejectsMalformedResourceWithContext(t *testing.T) {
+	setup()
+	defer teardown()
 
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "orgID must be supplied")
+	mux.HandleFunc("/orgs/org-id/projects", func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = fmt.Fprint(w, `{
+			"data": [
+				{"id":"project-1","type":"project","attributes":{}},
+				{"id":"project-2","type":"target","attributes":{}}
+			]
+		}`)
+	})
+
+	projects, response, err := client.Projects.List(ctx, "org-id", nil)
+
+	assert.Nil(t, projects)
+	require.NotNil(t, response)
+	assert.EqualError(t, err, `convert project at index 1: project "project-2": resource type is "target", expected "project"`)
 }
 
-func TestProject_Get(t *testing.T) {
+func TestProjects_List_rejectsMissingOrNullData(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "missing data", body: `{"links": {}}`},
+		{name: "null data", body: `{"data": null, "links": {}}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setup()
+			defer teardown()
+
+			mux.HandleFunc("/orgs/org-id/projects", func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = fmt.Fprint(w, tt.body)
+			})
+
+			projects, response, err := client.Projects.List(ctx, "org-id", nil)
+
+			assert.Nil(t, projects)
+			require.NotNil(t, response)
+			assert.EqualError(t, err, "convert projects: response data is missing")
+		})
+	}
+}
+
+func TestProjects_List_validatesOrgID(t *testing.T) {
+	projects, response, err := client.Projects.List(ctx, "", nil)
+
+	assert.Nil(t, projects)
+	assert.Nil(t, response)
+	require.ErrorIs(t, err, ErrEmptyArgument)
+	require.EqualError(t, err, "organization ID: argument is empty")
+}
+
+func TestProjects_All_multiplePages(t *testing.T) {
+	setup()
+	defer teardown()
+
+	page1 := loadFixture(t, "projects_all_page_1.json")
+	page2 := loadFixture(t, "projects_all_page_2.json")
+	options := &ProjectListOptions{
+		ListOptions:     ListOptions{StartingAfter: "initial-cursor", Limit: 10},
+		Names:           []string{"fake-project"},
+		Origins:         []ProjectOrigin{"github-cloud-app"},
+		TargetReference: "main",
+	}
+	requestCount := 0
+	mux.HandleFunc("/orgs/org-id/projects", func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		assert.Equal(t, http.MethodGet, r.Method)
+		assertRequestAPIVersion(t, r, projectsAPIVersion)
+		switch requestCount {
+		case 1:
+			assert.Equal(t, url.Values{
+				"limit":            {"10"},
+				"names":            {"fake-project"},
+				"origins":          {"github-cloud-app"},
+				"starting_after":   {"initial-cursor"},
+				"target_reference": {"main"},
+				"version":          {projectsAPIVersion},
+			}, r.URL.Query())
+			_, _ = w.Write(page1)
+		case 2:
+			assert.Equal(t, url.Values{
+				"limit":            {"10"},
+				"names":            {"fake-project"},
+				"origins":          {"github-cloud-app"},
+				"starting_after":   {"next-cursor"},
+				"target_reference": {"main"},
+				"version":          {projectsAPIVersion},
+			}, r.URL.Query())
+			_, _ = w.Write(page2)
+		default:
+			http.Error(w, "unexpected pagination request", http.StatusInternalServerError)
+		}
+	})
+
+	seq, iterErr := client.Projects.All(ctx, "org-id", options)
+	var projects []Project
+	for project := range seq {
+		projects = append(projects, project)
+	}
+
+	require.NoError(t, iterErr())
+	require.Len(t, projects, 2)
+	assert.Equal(t, []string{
+		"11111111-1111-1111-1111-111111111111",
+		"22222222-2222-2222-2222-222222222222",
+	}, []string{projects[0].ID, projects[1].ID})
+	assert.Equal(t, ProjectType("sast"), projects[0].ProjectType)
+	assert.Equal(t, "Dockerfile", projects[1].TargetPath)
+	assert.Equal(t, 2, requestCount)
+	assert.Equal(t, &ProjectListOptions{
+		ListOptions:     ListOptions{StartingAfter: "initial-cursor", Limit: 10},
+		Names:           []string{"fake-project"},
+		Origins:         []ProjectOrigin{"github-cloud-app"},
+		TargetReference: "main",
+	}, options)
+}
+
+func TestProjects_All_snapshotsOptionsAtConstruction(t *testing.T) {
+	setup()
+	defer teardown()
+
+	options := &ProjectListOptions{
+		ListOptions:  ListOptions{StartingAfter: "original-cursor", Limit: 10},
+		IDs:          []string{"original-id"},
+		Names:        []string{"original-name"},
+		NamePrefixes: []string{"original-prefix"},
+		ProjectTypes: []ProjectType{"original-type"},
+		Origins:      []ProjectOrigin{"original-origin"},
+	}
+	seq, iterErr := client.Projects.All(ctx, "org-id", options)
+
+	options.StartingAfter = "changed-cursor"
+	options.EndingBefore = "changed-ending-cursor"
+	options.Limit = 99
+	options.IDs = []string{"replacement-id"}
+	options.Names[0] = "mutated-name"
+	options.NamePrefixes[0] = "mutated-prefix"
+	options.ProjectTypes[0] = "mutated-type"
+	options.Origins[0] = "mutated-origin"
+
+	requestCount := 0
+	mux.HandleFunc("/orgs/org-id/projects", func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		assert.Equal(t, url.Values{
+			"ids":              {"original-id"},
+			"limit":            {"10"},
+			"names":            {"original-name"},
+			"names_start_with": {"original-prefix"},
+			"origins":          {"original-origin"},
+			"starting_after":   {"original-cursor"},
+			"types":            {"original-type"},
+			"version":          {projectsAPIVersion},
+		}, r.URL.Query())
+		_, _ = fmt.Fprint(w, `{"data":[],"links":{}}`)
+	})
+
+	for range seq {
+	}
+
+	require.NoError(t, iterErr())
+	assert.Equal(t, 1, requestCount)
+}
+
+func TestProjects_All_restartsSequentialIterationFromInitialCursor(t *testing.T) {
+	setup()
+	defer teardown()
+
+	page1 := loadFixture(t, "projects_all_page_1.json")
+	page2 := loadFixture(t, "projects_all_page_2.json")
+	requestCount := 0
+	mux.HandleFunc("/orgs/org-id/projects", func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		switch requestCount {
+		case 1, 3:
+			assert.Equal(t, "initial-cursor", r.URL.Query().Get("starting_after"))
+			_, _ = w.Write(page1)
+		case 2, 4:
+			assert.Equal(t, "next-cursor", r.URL.Query().Get("starting_after"))
+			_, _ = w.Write(page2)
+		default:
+			http.Error(w, "unexpected pagination request", http.StatusInternalServerError)
+		}
+	})
+
+	seq, iterErr := client.Projects.All(ctx, "org-id", &ProjectListOptions{ListOptions: ListOptions{StartingAfter: "initial-cursor"}})
+
+	var firstIteration []string
+	for project := range seq {
+		firstIteration = append(firstIteration, project.ID)
+	}
+	require.NoError(t, iterErr())
+
+	var secondIteration []string
+	for project := range seq {
+		secondIteration = append(secondIteration, project.ID)
+	}
+	require.NoError(t, iterErr())
+
+	wantProjectIDs := []string{
+		"11111111-1111-1111-1111-111111111111",
+		"22222222-2222-2222-2222-222222222222",
+	}
+	assert.Equal(t, wantProjectIDs, firstIteration)
+	assert.Equal(t, wantProjectIDs, secondIteration)
+	assert.Equal(t, 4, requestCount)
+}
+
+func TestProjects_All_rejectsEndingBefore(t *testing.T) {
+	setup()
+	defer teardown()
+
+	seq, iterErr := client.Projects.All(ctx, "org-id", &ProjectListOptions{
+		ListOptions: ListOptions{EndingBefore: "previous-cursor"},
+	})
+	for range seq {
+		t.Fatal("unexpected Project")
+	}
+
+	assert.EqualError(t, iterErr(), "ending-before pagination is not supported when iterating all projects")
+}
+
+func TestProjects_All_convertsEachPageAtomically(t *testing.T) {
+	setup()
+	defer teardown()
+
+	requestCount := 0
+	mux.HandleFunc("/orgs/org-id/projects", func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if r.URL.Query().Get("starting_after") == "second-page" {
+			_, _ = fmt.Fprint(w, `{
+				"data": [
+					{"id":"project-3","type":"project","attributes":{"name":"Third"}},
+					{"id":"project-4","type":"target","attributes":{"name":"Fourth"}}
+				],
+				"links": {}
+			}`)
+			return
+		}
+
+		_, _ = fmt.Fprint(w, `{
+			"data": [
+				{"id":"project-1","type":"project","attributes":{"name":"First"}},
+				{"id":"project-2","type":"project","attributes":{"name":"Second"}}
+			],
+			"links": {"next":"/rest/orgs/org-id/projects?starting_after=second-page"}
+		}`)
+	})
+
+	seq, iterErr := client.Projects.All(ctx, "org-id", nil)
+	var projectIDs []string
+	for project := range seq {
+		projectIDs = append(projectIDs, project.ID)
+	}
+
+	assert.Equal(t, []string{"project-1", "project-2"}, projectIDs)
+	assert.EqualError(t, iterErr(), `convert project at index 1: project "project-4": resource type is "target", expected "project"`)
+	assert.Equal(t, 2, requestCount)
+}
+
+func TestProjects_All_rejectsMissingOrNullData(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "missing data", body: `{"links": {}}`},
+		{name: "null data", body: `{"data": null, "links": {}}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setup()
+			defer teardown()
+
+			mux.HandleFunc("/orgs/org-id/projects", func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = fmt.Fprint(w, tt.body)
+			})
+
+			seq, iterErr := client.Projects.All(ctx, "org-id", nil)
+			for range seq {
+				t.Fatal("unexpected Project")
+			}
+
+			assert.EqualError(t, iterErr(), "convert projects: response data is missing")
+		})
+	}
+}
+
+func TestProjects_All_propagatesRESTErrorResponse(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/org-id/projects", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(headerSnykVersionServed, "2025-11-05")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = fmt.Fprint(w, `{"errors":[{"status":"503","title":"Temporarily unavailable"}]}`)
+	})
+
+	seq, iterErr := client.Projects.All(ctx, "org-id", nil)
+	for range seq {
+		t.Fatal("unexpected Project")
+	}
+
+	err := iterErr()
+	require.Error(t, err)
+	var errorResponse *ErrorResponse
+	require.ErrorAs(t, err, &errorResponse)
+	require.NotNil(t, errorResponse.Response)
+	assert.Equal(t, http.StatusServiceUnavailable, errorResponse.Response.StatusCode)
+	assert.Equal(t, "2025-11-05", errorResponse.Response.ServedAPIVersion)
+}
+
+func TestProjects_All_validatesOrgID(t *testing.T) {
+	seq, iterErr := client.Projects.All(ctx, "", nil)
+	for range seq {
+		t.Fatal("unexpected Project")
+	}
+
+	err := iterErr()
+	require.ErrorIs(t, err, ErrEmptyArgument)
+	require.EqualError(t, err, "organization ID: argument is empty")
+}
+
+func TestProjects_Get_success(t *testing.T) {
+	setup()
+	defer teardown()
+
+	fixture := loadFixture(t, "projects_get_success.json")
+	mux.HandleFunc("/orgs/org-id/projects/project-id", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, restAPIMediaType, r.Header.Get("Accept"))
+		assertRequestAPIVersion(t, r, projectsAPIVersion)
+		assert.Equal(t, url.Values{"version": {projectsAPIVersion}}, r.URL.Query())
+		_, _ = w.Write(fixture)
+	})
+
+	project, response, err := client.Projects.Get(ctx, "org-id", "project-id")
+
+	require.NoError(t, err)
+	require.NotNil(t, response)
+	assert.Equal(t, &Project{
+		ID:               "11111111-1111-1111-1111-111111111111",
+		Name:             "fake-org/fake-repository:catalog-info.yaml",
+		ProjectType:      ProjectType("k8sconfig"),
+		Origin:           ProjectOrigin("github-cloud-app"),
+		MonitoringStatus: ProjectMonitoringStatusActive,
+		TargetPath:       "catalog-info.yaml",
+		TargetReference:  "main",
+	}, project)
+}
+
+func TestProjects_Get_validatesIDs(t *testing.T) {
+	project, response, err := client.Projects.Get(ctx, "", "project-id")
+	assert.Nil(t, project)
+	assert.Nil(t, response)
+	require.ErrorIs(t, err, ErrEmptyArgument)
+	require.EqualError(t, err, "organization ID: argument is empty")
+
+	project, response, err = client.Projects.Get(ctx, "org-id", "")
+	assert.Nil(t, project)
+	assert.Nil(t, response)
+	require.ErrorIs(t, err, ErrEmptyArgument)
+	require.EqualError(t, err, "project ID: argument is empty")
+}
+
+func TestProjects_Get_propagatesRESTErrorResponse(t *testing.T) {
+	setup()
+	defer teardown()
+
+	mux.HandleFunc("/orgs/org-id/projects/missing", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(headerSnykVersionServed, "2024-05-31")
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = fmt.Fprint(w, `{"errors":[{"status":"404","title":"Project not found"}]}`)
+	})
+
+	project, response, err := client.Projects.Get(ctx, "org-id", "missing")
+
+	assert.Nil(t, project)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrEmptyArgument)
+	require.NotNil(t, response)
+	assert.Equal(t, http.StatusNotFound, response.StatusCode)
+	assert.Equal(t, "2024-05-31", response.ServedAPIVersion)
+	var errorResponse *ErrorResponse
+	require.ErrorAs(t, err, &errorResponse)
+	assert.Same(t, response, errorResponse.Response)
+	assert.Equal(t, "Project not found", errorResponse.APIErrors[0].Title)
+}
+
+func TestProjects_Delete_success(t *testing.T) {
 	setup()
 	defer teardown()
 
 	mux.HandleFunc("/orgs/org-id/projects/project-id", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodDelete, r.Method)
+		assert.Equal(t, restAPIMediaType, r.Header.Get("Accept"))
+		assert.Equal(t, restAPIMediaType, r.Header.Get("Content-Type"))
 		assertRequestAPIVersion(t, r, projectsAPIVersion)
-		_, _ = fmt.Fprint(w, `
-{
-  "jsonapi": { "version": "1.0" },
-  "data": {
-    "type": "project",
-    "id": "7f76f013-a3fd-4151-95e2-b3a347dc8546",
-    "meta": {},
-    "attributes": {
-      "name": "test-user/test-project-1:package.json",
-      "type": "npm",
-      "target_file": "package.json",
-      "target_reference": "main",
-      "origin": "gitlab",
-      "created": "2012-12-12T12:12:12.127Z",
-      "status": "active",
-      "business_criticality": [ "medium", "low" ],
-      "environment": [ "external" ],
-      "lifecycle": [ "development" ],
-      "tags": [],
-      "read_only": false,
-      "settings": { "recurring_tests": { "frequency": "weekly" }, "pull_requests": {} }
-    },
-    "relationships": {
-      "organization": {
-        "data": { "type": "org", "id": "2bd5babe-884b-49c5-9e82-0ce9f2a3a147" },
-        "links": {}
-      },
-      "target": {
-        "data": { "type": "target", "id": "ccd00feb-45c1-4e03-80c3-8eba50fac80a" },
-        "links": { "related": "/rest/orgs/2bd5babe-884b-49c5-9e82-0ce9f2a3a147/targets/ccd00feb-45c1-4e03-80c3-8eba50fac80a" }
-      },
-      "owner": {
-        "data": { "type": "user", "id": "f210d0ed-61b2-4588-a997-56346f61a7a7" },
-        "links": { "related": "/rest/orgs/2bd5babe-884b-49c5-9e82-0ce9f2a3a147/users/f210d0ed-61b2-4588-a997-56346f61a7a7" }
-			},
-      "importer": {
-        "data": { "type": "user", "id": "f210d0ed-61b2-4588-a997-56346f61a7a7" },
-        "links": { "related": "/rest/orgs/2bd5babe-884b-49c5-9e82-0ce9f2a3a147/users/f210d0ed-61b2-4588-a997-56346f61a7a7" }
-      }
-    }
-  },
-  "links": {}
-}
-`)
+		assert.Equal(t, url.Values{"version": {projectsAPIVersion}}, r.URL.Query())
+		w.WriteHeader(http.StatusNoContent)
 	})
-	createdAtTime, _ := time.Parse(time.RFC3339, "2012-12-12T12:12:12.127Z")
-	expectedProject := &Project{
-		ID:   "7f76f013-a3fd-4151-95e2-b3a347dc8546",
-		Type: "project",
-		Attributes: &ProjectAttributes{
-			CreatedAt:       createdAtTime,
-			Name:            "test-user/test-project-1:package.json",
-			Origin:          "gitlab",
-			Status:          "active",
-			TargetFile:      "package.json",
-			TargetReference: "main",
-			Type:            "npm",
-		},
-	}
 
-	actualProject, _, err := client.Projects.Get(ctx, "org-id", "project-id")
+	response, err := client.Projects.Delete(ctx, "org-id", "project-id")
 
-	assert.NoError(t, err)
-	assert.Equal(t, expectedProject, actualProject)
+	require.NoError(t, err)
+	require.NotNil(t, response)
+	assert.Equal(t, http.StatusNoContent, response.StatusCode)
 }
 
-func TestProject_Get_emptyOrgID(t *testing.T) {
-	_, _, err := client.Projects.Get(ctx, "", "project-id")
+func TestProjects_Delete_validatesIDs(t *testing.T) {
+	response, err := client.Projects.Delete(ctx, "", "project-id")
+	assert.Nil(t, response)
+	require.ErrorIs(t, err, ErrEmptyArgument)
+	require.EqualError(t, err, "organization ID: argument is empty")
 
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "orgID must be supplied")
+	response, err = client.Projects.Delete(ctx, "org-id", "")
+	assert.Nil(t, response)
+	require.ErrorIs(t, err, ErrEmptyArgument)
+	require.EqualError(t, err, "project ID: argument is empty")
 }
 
-func TestProject_Get_emptyProjectID(t *testing.T) {
-	_, _, err := client.Projects.Get(ctx, "org-id", "")
+func TestProjects_Delete_propagatesRESTErrorResponse(t *testing.T) {
+	setup()
+	defer teardown()
 
-	assert.Error(t, err)
-	assert.ErrorContains(t, err, "projectID must be supplied")
+	mux.HandleFunc("/orgs/org-id/projects/project-id", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set(headerSnykVersionServed, "2024-05-31")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = fmt.Fprint(w, `{"errors":[{"status":"403","title":"Insufficient permissions"}]}`)
+	})
+
+	response, err := client.Projects.Delete(ctx, "org-id", "project-id")
+
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrEmptyArgument)
+	require.NotNil(t, response)
+	assert.Equal(t, http.StatusForbidden, response.StatusCode)
+	assert.Equal(t, "2024-05-31", response.ServedAPIVersion)
+	var errorResponse *ErrorResponse
+	require.ErrorAs(t, err, &errorResponse)
+	assert.Same(t, response, errorResponse.Response)
+}
+
+func mustStartingAfter(t *testing.T, path string) string {
+	t.Helper()
+
+	cursor, err := extractStartingAfterQueryParam(path)
+	require.NoError(t, err)
+	return cursor
 }

--- a/snyk/testdata/projects_all_page_1.json
+++ b/snyk/testdata/projects_all_page_1.json
@@ -1,0 +1,19 @@
+{
+  "data": [
+    {
+      "type": "project",
+      "id": "11111111-1111-1111-1111-111111111111",
+      "attributes": {
+        "name": "fake-org/fake-repository",
+        "type": "sast",
+        "origin": "github-cloud-app",
+        "status": "active",
+        "target_file": "",
+        "target_reference": "main"
+      }
+    }
+  ],
+  "links": {
+    "next": "/rest/orgs/org-id/projects?version=server-version&starting_after=next-cursor&ending_before=untrusted&limit=99&origins=untrusted"
+  }
+}

--- a/snyk/testdata/projects_all_page_2.json
+++ b/snyk/testdata/projects_all_page_2.json
@@ -1,0 +1,17 @@
+{
+  "data": [
+    {
+      "type": "project",
+      "id": "22222222-2222-2222-2222-222222222222",
+      "attributes": {
+        "name": "fake-org/fake-repository:Dockerfile",
+        "type": "dockerfile",
+        "origin": "github-cloud-app",
+        "status": "active",
+        "target_file": "Dockerfile",
+        "target_reference": "main"
+      }
+    }
+  ],
+  "links": {}
+}

--- a/snyk/testdata/projects_get_success.json
+++ b/snyk/testdata/projects_get_success.json
@@ -1,0 +1,51 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "data": {
+    "type": "project",
+    "id": "11111111-1111-1111-1111-111111111111",
+    "attributes": {
+      "name": "fake-org/fake-repository:catalog-info.yaml",
+      "type": "k8sconfig",
+      "origin": "github-cloud-app",
+      "status": "active",
+      "target_file": "catalog-info.yaml",
+      "target_reference": "main",
+      "created": "2025-02-03T04:05:06Z",
+      "read_only": false,
+      "business_criticality": [
+        "high"
+      ],
+      "environment": [
+        "external"
+      ],
+      "lifecycle": [
+        "production"
+      ],
+      "tags": [],
+      "settings": {
+        "recurring_tests": {
+          "frequency": "weekly"
+        }
+      }
+    },
+    "meta": {
+      "latest_issue_counts": {
+        "critical": 1,
+        "high": 2,
+        "medium": 3,
+        "low": 4,
+        "updated_at": "2025-02-04T04:05:06Z"
+      }
+    },
+    "relationships": {
+      "organization": {
+        "data": {
+          "type": "org",
+          "id": "22222222-2222-2222-2222-222222222222"
+        }
+      }
+    }
+  }
+}

--- a/snyk/testdata/projects_list_success.json
+++ b/snyk/testdata/projects_list_success.json
@@ -1,0 +1,54 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "data": [
+    {
+      "type": "project",
+      "id": "11111111-1111-1111-1111-111111111111",
+      "attributes": {
+        "name": "fake-image:/usr/local/lib/node_modules",
+        "type": "npm",
+        "origin": "cli",
+        "status": "active",
+        "target_file": "/usr/local/lib/node_modules",
+        "target_reference": "docker-image|fake-image",
+        "created": "2025-01-02T03:04:05Z",
+        "read_only": false,
+        "tags": [
+          {
+            "key": "team",
+            "value": "fake-team"
+          }
+        ],
+        "settings": {}
+      },
+      "relationships": {
+        "target": {
+          "data": {
+            "type": "target",
+            "id": "33333333-3333-3333-3333-333333333333"
+          }
+        }
+      }
+    },
+    {
+      "type": "project",
+      "id": "22222222-2222-2222-2222-222222222222",
+      "attributes": {
+        "name": "fake-org/fake-repository",
+        "type": "sast",
+        "origin": "github-cloud-app",
+        "status": "inactive",
+        "target_file": "",
+        "target_reference": "main",
+        "created": "2025-01-03T03:04:05Z",
+        "read_only": false,
+        "settings": {}
+      }
+    }
+  ],
+  "links": {
+    "next": "/rest/orgs/org-id/projects?version=server-version&starting_after=next-cursor&limit=99&origins=untrusted"
+  }
+}

--- a/snyk/users_test.go
+++ b/snyk/users_test.go
@@ -44,7 +44,7 @@ import (
 //}
 
 func TestUsers_GetSelf(t *testing.T) {
-	setup()
+	setup(t)
 	defer teardown()
 
 	mux.HandleFunc("/self", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Establish Projects as the paved path for new v2 services.

  - Introduce an SDK-owned `Project` model and resource-first `ProjectListOptions`.
  - Add validated List, All, Get, and Delete operations.
  - Add callback-based pagination with deep option snapshots, page-atomic conversion, and cursor-cycle protection.
  - Replace SDK-owned service interfaces with concrete services and consumer-owned interfaces.
  - Centralize shared transport/error tests and expand Projects coverage.

  This intentionally changes the preview v2 API. See `MIGRATION.md` for migration guidance.